### PR TITLE
Persist Enketo encryption key; enhancements for dev mode

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -476,6 +476,7 @@ class Config:
             "postgres_hard_drive_type": "hdd",
             "postgres_settings_content": "",
             "enketo_api_token": binascii.hexlify(os.urandom(60)).decode("utf-8"),
+            "enketo_encryption_key": binascii.hexlify(os.urandom(60)).decode("utf-8"),
             "django_secret_key": binascii.hexlify(os.urandom(24)).decode("utf-8"),
             "use_backup": Config.FALSE,
             "kobocat_media_schedule": "0 0 * * 0",

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -109,6 +109,7 @@ class Template:
             "AWS_BACKUP_BUCKET_DELETION_RULE_ENABLED": "False" if config.get(
                 "aws_backup_bucket_deletion_rule_enabled") == Config.FALSE else "True",
             "LETSENCRYPT_EMAIL": config.get("letsencrypt_email"),
+            "ENKETO_ENCRYPTION_KEY": config.get("enketo_encryption_key")
         }
 
         environment_directory = config_object.get_env_files_path()

--- a/templates/kobo-deployments/enketo_express/config.json.tpl
+++ b/templates/kobo-deployments/enketo_express/config.json.tpl
@@ -2,7 +2,8 @@
     "app name": "Enketo Express for KoBo Toolbox",
     "linked form and data server": {
         "name": "KoBo Toolbox",
-        "server url": ""
+        "server url": "",
+        "encryption key": "${ENKETO_ENCRYPTION_KEY}"
     },
     "widgets": [
         "note", "select-desktop", "select-mobile", "autocomplete", "geo", "textarea",

--- a/templates/kobo-deployments/envfiles/nginx.txt.tpl
+++ b/templates/kobo-deployments/envfiles/nginx.txt.tpl
@@ -1,7 +1,7 @@
 # Options for the following are "uWSGI" or "runserver_plus" (for debugging).
 KPI_WEB_SERVER=${WSGI_SERVER}
 # django extensions are not installed on KoBoCat. So only `uWSGI` option is available.
-KOBOCAT_WEB_SERVER=uWSGI
+KOBOCAT_WEB_SERVER=${WSGI_SERVER}
 
 # Options for the following are "Nginx" or "Django".
 # NOTE: In order to serve static files from Django, the corresponding 


### PR DESCRIPTION
- Activate Django debugger when dev mode is chosen
- Persist enketo Encryption key to start faster after first build

Should be merged at the time at this PR:  https://github.com/kobotoolbox/kobo-docker/pull/247 