### PR TITLE
Changed dead link

### DIFF
--- a/templates/nginx-certbot/init-letsencrypt.sh.tpl
+++ b/templates/nginx-certbot/init-letsencrypt.sh.tpl
@@ -23,7 +23,7 @@ fi
 if [ ! -e "$$DATA_PATH/conf/options-ssl-nginx.conf" ] || [ ! -e "$$DATA_PATH/conf/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
   $$MKDIR_CMD -p "$$DATA_PATH/conf"
-  $$CURL_CMD -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/options-ssl-nginx.conf > "$$DATA_PATH/conf/options-ssl-nginx.conf"
+  $$CURL_CMD -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/tls_configs/options-ssl-nginx.conf > "$$DATA_PATH/conf/options-ssl-nginx.conf"
   $$CURL_CMD -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/ssl-dhparams.pem > "$$DATA_PATH/conf/ssl-dhparams.pem"
   echo
 fi


### PR DESCRIPTION
I've found dead link and update on lived in this files:

 **grep -R options-ssl-nginx.conf**

```
kobo-install/templates/nginx-certbot/init-letsencrypt.sh.tpl:  $$CURL_CMD -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/options-ssl-nginx.conf > "$$DATA_PATH/conf/options-ssl-nginx.conf"

nginx-certbot/init-letsencrypt.sh:  $CURL_CMD -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/options-ssl-
nginx.conf > "$DATA_PATH/conf/options-ssl-nginx.conf"
```

Please change all occurrences if it present in other files. 