### PR TITLE
Stay in maintenance mode until `--stop-maintenance` is invoked

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -9,6 +9,7 @@ import stat
 import string
 import sys
 import time
+import yaml
 from datetime import datetime
 from random import choice, randint
 
@@ -334,6 +335,16 @@ class Config:
             return False
 
         return True
+
+    def get_service_names(self):
+        yml_dump_command = ["docker-compose",
+                              "-f", "docker-compose.frontend.yml",
+                              "-f", "docker-compose.frontend.override.yml",
+                              "config"]
+
+        yml = CLI.run_command(yml_dump_command, self.__config["kobodocker_path"])
+        combined_config = yaml.load(yml)
+        return list(combined_config['services'].keys())
 
     def __create_directory(self):
         """

--- a/run.py
+++ b/run.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         elif sys.argv[1] == "-v" or sys.argv[1] == "--version":
             Command.version()
         elif sys.argv[1] == "-m" or sys.argv[1] == "--maintenance":
-            Command.maintenance()
+            Command.configure_maintenance()
         elif sys.argv[1] == "-sm" or sys.argv[1] == "--stop-maintenance":
             Command.stop_maintenance()
         else:


### PR DESCRIPTION
A maintenance process might involve reconfiguring and restarting services, and the application should remain closed to public traffic until the administrator signals that the work is done.