### PR TITLE
Deprecation of Python 2 

### DIFF
--- a/helpers/command.py
+++ b/helpers/command.py
@@ -177,7 +177,7 @@ class Command:
                 password, " " * (max_chars_count - password_chars_count)), CLI.COLOR_WARNING)
             CLI.colored_print("╚═{}═╝".format("═" * max_chars_count), CLI.COLOR_WARNING)
         else:
-            CLI.colored_print("KoBoToolbox could not start! Please try `python run.py --logs` to see the logs.", CLI.COLOR_ERROR)
+            CLI.colored_print("KoBoToolbox could not start! Please try `python3 run.py --logs` to see the logs.", CLI.COLOR_ERROR)
 
         return success
 

--- a/readme.md
+++ b/readme.md
@@ -9,34 +9,34 @@ Follow [those steps](https://github.com/kobotoolbox/kobo-docker#upgrading-from-a
 
 ## Usage
 
-`$kobo-install> python run.py`
+`$kobo-install> python3 run.py`
 
 First time the command is executed, setup will be launched.   
 Subsequent executions will launch docker containers directly.
 
 Rebuild configuration:  
-`$kobo-install> python run.py --setup`
+`$kobo-install> python3 run.py --setup`
 
 Get info:  
-`$kobo-install> python run.py --info`
+`$kobo-install> python3 run.py --info`
 
 Get docker logs:  
-`$kobo-install> python run.py --logs`
+`$kobo-install> python3 run.py --logs`
 
 Upgrade KoBoToolbox:  
-`$kobo-install> python run.py --upgrade`
+`$kobo-install> python3 run.py --upgrade`
 
 Stop KoBoToolbox:  
-`$kobo-install> python run.py --stop`
+`$kobo-install> python3 run.py --stop`
 
 Get help:  
-`$kobo-install> python run.py --help`
+`$kobo-install> python3 run.py --help`
 
 Get version:  
-`$kobo-install> python run.py --version`
+`$kobo-install> python3 run.py --version`
 
 Build kpi and kobocat (dev mode):  
-`$kobo-install> python run.py --build`
+`$kobo-install> python3 run.py --build`
 
 
 **Be aware, this utility is a beta release and may still have bugs.**
@@ -96,7 +96,7 @@ User can choose between 2 types of installations:
 ## Requirements
 
 - Linux / macOS
-- Python 2.7+/3.5+
+- Python 2.7/3.5+ <sup>Python2 support will be dropped in a future release</sup>
 - [Docker](https://www.docker.com/get-started "") & [Docker Compose](https://docs.docker.com/compose/install/ "")
 - Available TCP Ports:
 
@@ -114,8 +114,8 @@ Tests can be run with `tox`.
 Be sure it's install before running the tests
 
 ```
-$kobo-install> sudo apt install python-pip
-$kobo-install> pip install tox
+$kobo-install> sudo apt install python3-pip
+$kobo-install> pip3 install tox
 $kobo-install> tox
 ```
 or 

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
 

--- a/run.py
+++ b/run.py
@@ -14,6 +14,14 @@ from helpers.template import Template
 
 def run(force_setup=False):
 
+    if sys.version_info[0] == 2:
+        CLI.colored_print("╔═══════════════════════════════════════════════════════════════╗", CLI.COLOR_ERROR)
+        CLI.colored_print("║ DEPRECATION: Python 2.7 has reached the end of its life on    ║", CLI.COLOR_ERROR)
+        CLI.colored_print("║ January 1st, 2020. Please upgrade your Python as Python 2.7   ║", CLI.COLOR_ERROR)
+        CLI.colored_print("║ is not maintained anymore.                                    ║", CLI.COLOR_ERROR)
+        CLI.colored_print("║ A future version of KoBoInstall will drop support for it.     ║", CLI.COLOR_ERROR)
+        CLI.colored_print("╚═══════════════════════════════════════════════════════════════╝", CLI.COLOR_ERROR)
+
     if not platform.system() in ["Linux", "Darwin"]:
         CLI.colored_print("Not compatible with this OS", CLI.COLOR_ERROR)
     else:

--- a/templates/kobo-deployments/enketo_express/config.json.tpl
+++ b/templates/kobo-deployments/enketo_express/config.json.tpl
@@ -58,19 +58,19 @@
         {
             "name": "humanitarian",
             "tiles": [ "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png" ],
-            "attribution": "© <a href=\"http://openstreetmap.org\">OpenStreetMap</a> & <a href=\"https://www.hotosm.org/updates/2013-09-29_a_new_window_on_openstreetmap_data\">Yohan Boniface & Humanitarian OpenStreetMap Team</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
+            "attribution": "&copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> & <a href=\"https://www.hotosm.org/updates/2013-09-29_a_new_window_on_openstreetmap_data\">Yohan Boniface & Humanitarian OpenStreetMap Team</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
         }, {
             "name": "satellite",
             "tiles": [ "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}" ],
-            "attribution": "Tiles © Esri — Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+            "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
         }, {
             "name": "terrain",
             "tiles": [ "https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png" ],
-            "attribution": "© <a href=\"https://openstreetmap.org\">OpenStreetMap</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
+            "attribution": "&copy; <a href=\"https://openstreetmap.org\">OpenStreetMap</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
         }, {
             "name": "streets",
             "tiles": [ "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" ],
-            "attribution": "© <a href=\"https://openstreetmap.org\">OpenStreetMap</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
+            "attribution": "&copy; <a href=\"https://openstreetmap.org\">OpenStreetMap</a> | <a href=\"https://www.openstreetmap.org/copyright\">Terms</a>"
         }
     ]
 }


### PR DESCRIPTION
Closes #75 

- Message appears with running KoBoInstall with Python2.
- Default version is now python3.
