### PR TITLE
Create dynamic `uwsgi_pass` timeout based on uWSGI Harakiri timeout

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -28,9 +28,9 @@ class Config:
     DEFAULT_PROXY_PORT = "8080"
     DEFAULT_NGINX_PORT = "80"
     DEFAULT_NGINX_HTTPS_PORT = "443"
-    KOBO_DOCKER_BRANCH = '2.020.24'
-    KOBO_INSTALL_BRANCH = 'master'
-    KOBO_INSTALL_VERSION = '2.3.0'
+    KOBO_DOCKER_BRANCH = 'dynamic-uwsgi-pass-timeout'
+    KOBO_INSTALL_BRANCH = 'dynamic-uwsgi-pass-timeout'
+    KOBO_INSTALL_VERSION = '2.4.1'
 
     # Maybe overkill. Use this class as a singleton to get the same configuration
     # for each instantiation.

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -199,6 +199,7 @@ class Template:
             "UWSGI_SOFT_LIMIT": int(config.get("uwsgi_soft_limit")) * 1024 * 1024,
             "UWSGI_HARAKIRI": config.get("uwsgi_harakiri"),
             "UWSGI_WORKER_RELOAD_MERCY": config.get("uwsgi_worker_reload_mercy"),
+            "UWSGI_PASS_TIMEOUT": int(config.get("uwsgi_harakiri")) + 10,
             "POSTGRES_REPLICATION_PASSWORD": config.get("postgres_replication_password"),
             "WSGI_SERVER": "runserver_plus" if config_object.dev_mode else "uWSGI",
             "USE_X_FORWARDED_HOST": "" if config_object.dev_mode else "#",

--- a/templates/kobo-docker/docker-compose.frontend.override.yml.tpl
+++ b/templates/kobo-docker/docker-compose.frontend.override.yml.tpl
@@ -62,6 +62,7 @@ services:
   nginx:
     environment:
       - NGINX_PUBLIC_PORT=${NGINX_PUBLIC_PORT}
+      - UWSGI_PASS_TIMEOUT=${UWSGI_PASS_TIMEOUT}
     ports:
       - ${NGINX_EXPOSED_PORT}:80
     ${USE_EXTRA_HOSTS}extra_hosts:


### PR DESCRIPTION
version was bumped to `2.4.1` because I created the issue for #98 first. 
IMHO, This one is more a patched version than a minor change. But you can change it to `2.5.0` if you want. 

Related to https://github.com/kobotoolbox/kobo-docker/pull/291