### PR TITLE
Fixed endless loop when updating kobo-install

### DIFF
--- a/helpers/updater.py
+++ b/helpers/updater.py
@@ -13,9 +13,10 @@ class Updater:
     Updates kobo-install (this utility), restarts this script, and updates
     kobo-docker
     """
+    NO_UPDATE_SELF_OPTION = '--no-update-self'
 
-    @staticmethod
-    def run(version='stable', cron=False, update_self=True):
+    @classmethod
+    def run(cls, version='stable', cron=False, update_self=True):
         # Validate kobo-docker already exists and is valid
         Setup.validate_already_run()
 
@@ -28,6 +29,7 @@ class Updater:
             # NB:`argv[0]` does not automatically get set to the executable
             # path as it usually would, so we have to do it manually--hence the
             # double `sys.executable`
+            sys.argv.append(cls.NO_UPDATE_SELF_OPTION)
             os.execl(sys.executable, sys.executable, *sys.argv)
 
         # Update kobo-docker

--- a/run.py
+++ b/run.py
@@ -49,10 +49,10 @@ if __name__ == "__main__":
     try:
 
         # avoid inifinte self-updating loops
-        update_self = not "--no-update-self" in sys.argv
+        update_self = Updater.NO_UPDATE_SELF_OPTION not in sys.argv
         while True:
             try:
-                sys.argv.remove("--no-update-self")
+                sys.argv.remove(Updater.NO_UPDATE_SELF_OPTION)
             except ValueError:
                 break
 


### PR DESCRIPTION
Kobo-install entered in an endless loop when running `./run.py --update`.  Because option `--no-update-self` was not passed to child process. 