### PR TITLE
quickfix: increase wait for database retries

### DIFF
--- a/helpers/upgrading.py
+++ b/helpers/upgrading.py
@@ -44,7 +44,7 @@ def migrate_single_to_two_databases():
                       CLI.COLOR_INFO)
     frontend_command = kpi_run_command + _kpi_db_alias_kludge(" ".join([
                            "python", "manage.py",
-                           "wait_for_database", "--retries", "45"
+                           "wait_for_database", "--retries", "300"
                        ]))
     CLI.run_command(frontend_command, config.get("kobodocker_path"))
     CLI.colored_print("The PostgreSQL database is running!", CLI.COLOR_SUCCESS)


### PR DESCRIPTION
 "wait_for_database", "--retries",
 _"45"_ to "300"
https://community.kobotoolbox.org/t/i-get-stuck-running-instalation-kobofe-kobo-fe-network-with-driver-bridge/9559
increasing wait time solved the issue above so that there would be enough time for Postgres to be ready