### PR TITLE
Add wal e support

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -766,22 +766,23 @@ class Config(with_metaclass(Singleton)):
                         self.__questions_aws()
 
                     # Prompting user whether they want to use WAL-E for
-                    # continuous archiving
-                    if self.primary_backend or not self.multi_servers:
-                        CLI.colored_print(
-                            "Do you want to use WAL-E for continuous archiving of PostgreSQL backups?", 
-                            CLI.COLOR_SUCCESS)   
-                        CLI.colored_print("\t1) Yes")
-                        CLI.colored_print("\t2) No")
-                        self.__config["use_wal_e"] = CLI.get_response(
-                            [Config.TRUE, Config.FALSE],
-                            self.__config.get("use_wal_e", Config.FALSE))
+                    # continuous archiving - only if they are using aws for backups
+                    if self.aws:
+                        if self.primary_backend or not self.multi_servers:
+                            CLI.colored_print(
+                                "Do you want to use WAL-E for continuous archiving of PostgreSQL backups?", 
+                                CLI.COLOR_SUCCESS)   
+                            CLI.colored_print("\t1) Yes")
+                            CLI.colored_print("\t2) No")
+                            self.__config["use_wal_e"] = CLI.get_response(
+                                [Config.TRUE, Config.FALSE],
+                                self.__config.get("use_wal_e", Config.FALSE))
 
-                        if self.__config.get('use_wal_e') == Config.TRUE:
-                            # Forcing postgres backup schedule and settings
-                            self.__config["postgres_backup_schedule"] == ''
-                            # Not entirely sure if this is what you were asking for
-                            self.__config["backup_from_primary"] = Config.TRUE
+                            if self.__config.get('use_wal_e') == Config.TRUE:
+                                # Forcing postgres backup schedule and settings
+                                self.__config["postgres_backup_schedule"] == ''
+                                # Not entirely sure if this is what you were asking for
+                                self.__config["backup_from_primary"] = Config.TRUE
 
                     schedule_regex_pattern = (r"^((((\d+(,\d+)*)|(\d+-\d+)|(\*(\/\d+)?)))"
                                               r"(\s+(((\d+(,\d+)*)|(\d+\-\d+)|(\*(\/\d+)?)))){4})$")
@@ -810,27 +811,25 @@ class Config(with_metaclass(Singleton)):
 
                     if self.backend_questions:
                         
-                        # Only asking these Postgres config questions if WAL-E not being used
-                        if self.__config['use_wal_e'] == Config.FALSE:
-                            if self.primary_backend:
-                                CLI.colored_print("Run PostgreSQL backup from primary backend server?",
-                                                CLI.COLOR_SUCCESS)
-                                CLI.colored_print("\t1) Yes")
-                                CLI.colored_print("\t2) No")
-                                self.__config["backup_from_primary"] = CLI.get_response(
-                                    [Config.TRUE, Config.FALSE],
-                                    self.__config.get("backup_from_primary", Config.TRUE))
+                        if self.primary_backend:
+                            CLI.colored_print("Run PostgreSQL backup from primary backend server?",
+                                            CLI.COLOR_SUCCESS)
+                            CLI.colored_print("\t1) Yes")
+                            CLI.colored_print("\t2) No")
+                            self.__config["backup_from_primary"] = CLI.get_response(
+                                [Config.TRUE, Config.FALSE],
+                                self.__config.get("backup_from_primary", Config.TRUE))
 
-                            backup_from_primary = self.__config["backup_from_primary"] == Config.TRUE
-                            if (not self.multi_servers or
-                                (self.primary_backend and backup_from_primary) or
-                                    (self.secondary_backend and not backup_from_primary)):
-                                CLI.colored_print("PostgreSQL backup schedule?", CLI.COLOR_SUCCESS)
-                                self.__config["postgres_backup_schedule"] = CLI.get_response(
-                                    "~{}".format(schedule_regex_pattern),
-                                    self.__config.get(
-                                        "postgres_backup_schedule",
-                                        "0 2 * * 0"))
+                        backup_from_primary = self.__config["backup_from_primary"] == Config.TRUE
+                        if (not self.multi_servers or
+                            (self.primary_backend and backup_from_primary) or
+                                (self.secondary_backend and not backup_from_primary)):
+                            CLI.colored_print("PostgreSQL backup schedule?", CLI.COLOR_SUCCESS)
+                            self.__config["postgres_backup_schedule"] = CLI.get_response(
+                                "~{}".format(schedule_regex_pattern),
+                                self.__config.get(
+                                    "postgres_backup_schedule",
+                                    "0 2 * * 0"))
 
                         if self.primary_backend or not self.multi_servers:
 

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -33,7 +33,7 @@ class Config(with_metaclass(Singleton)):
     DEFAULT_NGINX_PORT = "80"
     DEFAULT_NGINX_HTTPS_PORT = "443"
     KOBO_DOCKER_BRANCH = '2.020.40a'
-    KOBO_INSTALL_VERSION = '3.2.1'
+    KOBO_INSTALL_VERSION = '3.3.0'
 
     def __init__(self):
         self.__config = self.read_config()

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -295,6 +295,7 @@ class Config(with_metaclass(Singleton)):
             # we want to keep the same value when users upgrade.
             "enketo_less_secure_encryption_key": 'this $3cr3t key is crackable',
             "use_backup": Config.FALSE,
+            "use_wal_e": Config.FALSE,
             "kobocat_media_schedule": "0 0 * * 0",
             "mongo_backup_schedule": "0 1 * * 0",
             "postgres_backup_schedule": "0 2 * * 0",
@@ -748,6 +749,27 @@ class Config(with_metaclass(Singleton)):
                     if self.backend_questions and not self.frontend_questions:
                         self.__questions_aws()
 
+                    # Prompting user whether they want to use WAL-E for
+                    # continuous archiving
+                    if self.primary_backend or not self.multi_servers:
+                        CLI.colored_print(
+                            "Do you want to use WAL-E for continuous archiving of backups?", 
+                            CLI.COLOR_SUCCESS)   
+                        CLI.colored_print("\t1) Yes")
+                        CLI.colored_print("\t2) No")
+                        self.__config["use_wal_e"] = CLI.get_response(
+                            [Config.TRUE, Config.FALSE],
+                            self.__config.get("use_wal_e", Config.FALSE))
+
+                        if self.__config.get('use_wal_e') == Config.TRUE:
+                            # Forcing postgres backup schedule and settings
+                            self.__config["postgres_backup_schedule"] == ''
+                            self.__config["postgres_settings"] = Config.TRUE
+                            # Not entirely sure if this is what you were asking for
+                            self.__config["backup_from_primary"] = Config.TRUE
+
+                    #   ------------------------------------------------------------  #
+
                     schedule_regex_pattern = (r"^((((\d+(,\d+)*)|(\d+-\d+)|(\*(\/\d+)?)))"
                                               r"(\s+(((\d+(,\d+)*)|(\d+\-\d+)|(\*(\/\d+)?)))){4})$")
                     CLI.colored_print("╔═════════════════════════════════════════════════════════════════╗",
@@ -774,26 +796,28 @@ class Config(with_metaclass(Singleton)):
                                 "0 0 * * 0"))
 
                     if self.backend_questions:
+                        
+                        # Only asking these Postgres config questions if WAL-E not being used
+                        if self.__config['use_wal_e'] == Config.FALSE:
+                            if self.primary_backend:
+                                CLI.colored_print("Run PostgreSQL backup from primary backend server?",
+                                                CLI.COLOR_SUCCESS)
+                                CLI.colored_print("\t1) Yes")
+                                CLI.colored_print("\t2) No")
+                                self.__config["backup_from_primary"] = CLI.get_response(
+                                    [Config.TRUE, Config.FALSE],
+                                    self.__config.get("backup_from_primary", Config.TRUE))
 
-                        if self.primary_backend:
-                            CLI.colored_print("Run PostgreSQL backup from primary backend server?",
-                                              CLI.COLOR_SUCCESS)
-                            CLI.colored_print("\t1) Yes")
-                            CLI.colored_print("\t2) No")
-                            self.__config["backup_from_primary"] = CLI.get_response(
-                                [Config.TRUE, Config.FALSE],
-                                self.__config.get("backup_from_primary", Config.TRUE))
-
-                        backup_from_primary = self.__config["backup_from_primary"] == Config.TRUE
-                        if (not self.multi_servers or
-                            (self.primary_backend and backup_from_primary) or
-                                (self.secondary_backend and not backup_from_primary)):
-                            CLI.colored_print("PostgreSQL backup schedule?", CLI.COLOR_SUCCESS)
-                            self.__config["postgres_backup_schedule"] = CLI.get_response(
-                                "~{}".format(schedule_regex_pattern),
-                                self.__config.get(
-                                    "postgres_backup_schedule",
-                                    "0 2 * * 0"))
+                            backup_from_primary = self.__config["backup_from_primary"] == Config.TRUE
+                            if (not self.multi_servers or
+                                (self.primary_backend and backup_from_primary) or
+                                    (self.secondary_backend and not backup_from_primary)):
+                                CLI.colored_print("PostgreSQL backup schedule?", CLI.COLOR_SUCCESS)
+                                self.__config["postgres_backup_schedule"] = CLI.get_response(
+                                    "~{}".format(schedule_regex_pattern),
+                                    self.__config.get(
+                                        "postgres_backup_schedule",
+                                        "0 2 * * 0"))
 
                         if self.primary_backend or not self.multi_servers:
 

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -32,8 +32,8 @@ class Config(with_metaclass(Singleton)):
     DEFAULT_PROXY_PORT = "8080"
     DEFAULT_NGINX_PORT = "80"
     DEFAULT_NGINX_HTTPS_PORT = "443"
-    KOBO_DOCKER_BRANCH = '2.020.40a'
-    KOBO_INSTALL_VERSION = '3.3.0'
+    KOBO_DOCKER_BRANCH = 'add-wale-support'
+    KOBO_INSTALL_VERSION = '3.4.0'
 
     def __init__(self):
         self.__config = self.read_config()

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -779,11 +779,14 @@ class Config(with_metaclass(Singleton)):
                                 [Config.TRUE, Config.FALSE],
                                 self.__config.get("use_wal_e", Config.FALSE))
 
-                            if self.__config.get('use_wal_e') == Config.TRUE:
-                                # Forcing postgres backup schedule and settings
-                                self.__config["postgres_backup_schedule"] == ''
-                                # Not entirely sure if this is what you were asking for
-                                self.__config["backup_from_primary"] = Config.TRUE
+                            if self.__config['use_wal_e'] == Config.TRUE:
+                                self.__config['backup_from_primary'] = Config.TRUE
+                        else:
+                            # WAL-E cannot run on secondary
+                            self.__config['use_wal_e'] = Config.FALSE
+                    else:
+                        # WAL-E is only supported with AWS
+                        self.__config['use_wal_e'] = Config.FALSE
 
                     schedule_regex_pattern = (r"^((((\d+(,\d+)*)|(\d+-\d+)|(\*(\/\d+)?)))"
                                               r"(\s+(((\d+(,\d+)*)|(\d+\-\d+)|(\*(\/\d+)?)))){4})$")
@@ -811,20 +814,20 @@ class Config(with_metaclass(Singleton)):
                                 "0 0 * * 0"))
 
                     if self.backend_questions:
-                        
                         if self.__config['use_wal_e'] == Config.TRUE:
-                            self.__config["backup_from_primary"] = Config.FALSE
+                            self.__config['backup_from_primary'] = Config.TRUE
                         else:
                             if self.primary_backend:
-                                CLI.colored_print("Run PostgreSQL backup from primary backend server?",
-                                                CLI.COLOR_SUCCESS)
+                                CLI.colored_print(
+                                    "Run PostgreSQL backup from primary backend server?",
+                                    CLI.COLOR_SUCCESS
+                                )
                                 CLI.colored_print("\t1) Yes")
                                 CLI.colored_print("\t2) No")
                                 self.__config["backup_from_primary"] = CLI.get_response(
                                     [Config.TRUE, Config.FALSE],
                                     self.__config.get("backup_from_primary", Config.TRUE))
                             else:
-                                print('I got here')
                                 self.__config["backup_from_primary"] = Config.FALSE
 
                         backup_from_primary = self.__config["backup_from_primary"] == Config.TRUE

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -215,7 +215,9 @@ class Template:
             "REDIS_MAIN_PORT": config.get("redis_main_port", "6739"),
             "REDIS_CACHE_PORT": config.get("redis_cache_port", "6380"),
             "USE_BACKUP": "" if config.get("use_backup") == Config.TRUE else "#",
-            "USE_WAL_E_BACKUP": "" if config.get("use_wal_e") == Config.TRUE else "#",
+            "USE_WAL_E_BACKUP": _get_value("use_wal_e", true_value="",
+                                                        false_value="#",
+                                                        comparison_value=Config.TRUE),
             "USE_WAL_E": config.get("use_wal_e"),
             "USE_AWS_BACKUP": "" if config_object.aws and
                                     config.get("use_backup") == Config.TRUE and

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -215,9 +215,7 @@ class Template:
             "REDIS_MAIN_PORT": config.get("redis_main_port", "6739"),
             "REDIS_CACHE_PORT": config.get("redis_cache_port", "6380"),
             "USE_BACKUP": "" if config.get("use_backup") == Config.TRUE else "#",
-            "USE_WAL_E_BACKUP": _get_value("use_wal_e", true_value="",
-                                                        false_value="#",
-                                                        comparison_value=Config.TRUE),
+            "USE_WAL_E_BACKUP": _get_value("use_wal_e"),
             "USE_WAL_E": config.get("use_wal_e"),
             "USE_AWS_BACKUP": "" if config_object.aws and
                                     config.get("use_backup") == Config.TRUE and

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -215,7 +215,8 @@ class Template:
             "REDIS_MAIN_PORT": config.get("redis_main_port", "6739"),
             "REDIS_CACHE_PORT": config.get("redis_cache_port", "6380"),
             "USE_BACKUP": "" if config.get("use_backup") == Config.TRUE else "#",
-            "USE_WAL_E": "" if config.get("use_wal_e") == Config.TRUE else "#",
+            "USE_WAL_E_BACKUP": "" if config.get("use_wal_e") == Config.TRUE else "#",
+            "USE_WAL_E": config.get("use_wal_e"),
             "USE_AWS_BACKUP": "" if config_object.aws and
                                     config.get("use_backup") == Config.TRUE and
                                     config.get("aws_backup_bucket_name") != "" else "#",

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -215,6 +215,7 @@ class Template:
             "REDIS_MAIN_PORT": config.get("redis_main_port", "6739"),
             "REDIS_CACHE_PORT": config.get("redis_cache_port", "6380"),
             "USE_BACKUP": "" if config.get("use_backup") == Config.TRUE else "#",
+            "USE_WAL_E": "" if config.get("use_wal_e") == Config.TRUE else "#",
             "USE_AWS_BACKUP": "" if config_object.aws and
                                     config.get("use_backup") == Config.TRUE and
                                     config.get("aws_backup_bucket_name") != "" else "#",

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -215,8 +215,7 @@ class Template:
             "REDIS_MAIN_PORT": config.get("redis_main_port", "6739"),
             "REDIS_CACHE_PORT": config.get("redis_cache_port", "6380"),
             "USE_BACKUP": "" if config.get("use_backup") == Config.TRUE else "#",
-            "USE_WAL_E_BACKUP": _get_value("use_wal_e"),
-            "USE_WAL_E": config.get("use_wal_e"),
+            "USE_WAL_E": _get_value("use_wal_e"),
             "USE_AWS_BACKUP": "" if config_object.aws and
                                     config.get("use_backup") == Config.TRUE and
                                     config.get("aws_backup_bucket_name") != "" else "#",

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ User can choose between 2 types of installations:
 |MongoDB user's password|  **Autogenerate**  | ✓ | ✓ |
 |Redis password<sup>4</sup>|  **Autogenerate**  | ✓ | ✓ |
 |Use AWS storage|  **No**  | ✓ | ✓ (frontend only) |
+|Use WAL-E PostgreSQL backups<sup>5</sup> |  **No**  | ✓ | ✓ (frontend only) |
 |uWGI workers|  **start: 2, max: 4**  | ✓ | ✓ (frontend only) |
 |uWGI memory limit|  **128 MB**  | ✓ | ✓ (frontend only) |
 |uWGI harakiri timeout |  **120s**  | ✓ | ✓ (frontend only) |
@@ -129,6 +130,8 @@ User can choose between 2 types of installations:
 <sup>3)</sup> _Custom settings are provided by [PostgreSQL Configuration Tool API](https://github.com/sebastianwebber/pgconfig-api "")_
 
 <sup>4)</sup> _Redis password is optional but **strongly** recommended_
+
+<sup>5)</sup> _WAL-E backups for PostgreSQL are only available when using AWS storage_
 
 ℹ  Intercom App ID [must now](https://github.com/kobotoolbox/kpi/pull/2285) be configured through "Per user settings" in the Django admin interface of KPI.
 

--- a/templates/kobo-docker/docker-compose.backend.primary.override.yml.tpl
+++ b/templates/kobo-docker/docker-compose.backend.primary.override.yml.tpl
@@ -4,8 +4,8 @@ version: '2.2'
 services:
 
   postgres:
-    ${OVERRIDE_POSTGRES_SETTINGS}volumes:
-    ${OVERRIDE_POSTGRES_SETTINGS}  - ../kobo-env/postgres/primary/postgres.conf:/kobo-docker-scripts/primary/postgres.conf
+    volumes:
+      - ../kobo-env/postgres/primary/postgres.conf:/kobo-docker-scripts/primary/postgres.conf
     ${POSTGRES_BACKUP_FROM_SECONDARY}environment:
     ${POSTGRES_BACKUP_FROM_SECONDARY}  - POSTGRES_BACKUP_FROM_SECONDARY=True
     ${EXPOSE_BACKEND_PORTS}ports:

--- a/templates/kobo-docker/docker-compose.backend.secondary.override.yml.tpl
+++ b/templates/kobo-docker/docker-compose.backend.secondary.override.yml.tpl
@@ -6,8 +6,8 @@ services:
     extends:
       file: docker-compose.backend.template.yml
       service: postgres
-    ${OVERRIDE_POSTGRES_SETTINGS}volumes:
-    ${OVERRIDE_POSTGRES_SETTINGS}  - ../kobo-env/postgres/secondary/postgres.conf:/kobo-docker-scripts/secondary/postgres.conf
+    volumes:
+      - ../kobo-env/postgres/secondary/postgres.conf:/kobo-docker-scripts/secondary/postgres.conf
     ports:
       - ${POSTGRES_PORT}:5432
     ${ADD_BACKEND_EXTRA_HOSTS}extra_hosts:

--- a/templates/kobo-env/envfiles/databases.txt.tpl
+++ b/templates/kobo-env/envfiles/databases.txt.tpl
@@ -43,7 +43,7 @@ KOBO_POSTGRES_PRIMARY_ENDPOINT=primary.postgres.${PRIVATE_DOMAIN_NAME}
 ${USE_BACKUP}POSTGRES_BACKUP_SCHEDULE=${POSTGRES_BACKUP_SCHEDULE}
 
 # WAL-E archiving and backup support
-{USE_WAL_E_BACKUP}USE_WAL_E=1
+${USE_WAL_E}USE_WAL_E=1
 
 #--------------------------------------------------------------------------------
 # REDIS

--- a/templates/kobo-env/envfiles/databases.txt.tpl
+++ b/templates/kobo-env/envfiles/databases.txt.tpl
@@ -42,6 +42,9 @@ KOBO_POSTGRES_PRIMARY_ENDPOINT=primary.postgres.${PRIVATE_DOMAIN_NAME}
 # Default Postgres backup schedule is weekly at 02:00 AM UTC on Sunday.
 ${USE_BACKUP}POSTGRES_BACKUP_SCHEDULE=${POSTGRES_BACKUP_SCHEDULE}
 
+# WAL-E archiving and backup support
+{USE_WAL_E_BACKUP}USE_WAL_E=1
+
 #--------------------------------------------------------------------------------
 # REDIS
 #--------------------------------------------------------------------------------

--- a/templates/kobo-env/postgres/primary/postgres.conf.tpl
+++ b/templates/kobo-env/postgres/primary/postgres.conf.tpl
@@ -14,3 +14,7 @@
 # Total Memory (RAM): ${POSTGRES_RAM}GB
 
 ${POSTGRES_SETTINGS}
+
+${USE_WAL_E}archive_mode = on
+${USE_WAL_E}archive_command = 'envdir /var/lib/postgresql/data/wal-e.d/env wal-e wal-push %p'
+${USE_WAL_E}archive_timeout = 60

--- a/templates/kobo-env/postgres/primary/postgres.conf.tpl
+++ b/templates/kobo-env/postgres/primary/postgres.conf.tpl
@@ -15,6 +15,6 @@
 
 ${POSTGRES_SETTINGS}
 
-${USE_WAL_E_BACKUP}archive_mode = on
-${USE_WAL_E_BACKUP}archive_command = 'envdir $$PGDATA/wal-e.d/env wal-e wal-push %p'
-${USE_WAL_E_BACKUP}archive_timeout = 60
+${USE_WAL_E}archive_mode = on
+${USE_WAL_E}archive_command = 'envdir $$PGDATA/wal-e.d/env wal-e wal-push %p'
+${USE_WAL_E}archive_timeout = 60

--- a/templates/kobo-env/postgres/primary/postgres.conf.tpl
+++ b/templates/kobo-env/postgres/primary/postgres.conf.tpl
@@ -15,6 +15,6 @@
 
 ${POSTGRES_SETTINGS}
 
-${USE_WAL_E}archive_mode = on
-${USE_WAL_E}archive_command = 'envdir /var/lib/postgresql/data/wal-e.d/env wal-e wal-push %p'
-${USE_WAL_E}archive_timeout = 60
+${USE_WAL_E_BACKUP}archive_mode = on
+${USE_WAL_E_BACKUP}archive_command = 'envdir /var/lib/postgresql/data/wal-e.d/env wal-e wal-push %p'
+${USE_WAL_E_BACKUP}archive_timeout = 60

--- a/templates/kobo-env/postgres/primary/postgres.conf.tpl
+++ b/templates/kobo-env/postgres/primary/postgres.conf.tpl
@@ -16,5 +16,5 @@
 ${POSTGRES_SETTINGS}
 
 ${USE_WAL_E_BACKUP}archive_mode = on
-${USE_WAL_E_BACKUP}archive_command = 'envdir /var/lib/postgresql/data/wal-e.d/env wal-e wal-push %p'
+${USE_WAL_E_BACKUP}archive_command = 'envdir $$PGDATA/wal-e.d/env wal-e wal-push %p'
 ${USE_WAL_E_BACKUP}archive_timeout = 60


### PR DESCRIPTION
Closes #119 

The main changes have been made to `config.py` and `postgres.conf.tpl` with minor changes to the docker-compose templates for both the primary and secondary override files.

Within `config.py`, the default value for `postgres_settings_content` was set to ensure that settings are always carried through to `kobo-env/postgres/primary/postgres.conf` and `kobo-env/postgres/secondary/postgres.conf`. I noticed that when there is a previous value set in `.run.conf`, the `postgres_settings_content` is not updated, so I forced this to update to the default value if the user answers "no" to the question, "Do you want to tweak PostgreSQL settings?".

If the user answers "yes" to "Do you want to activate backups?" and then "yes" to "Do you want to use WAL-E for continuous archiving of PostgreSQL backups?", they will not be asked about setting `backup_from_primary` or the cron schedule set to `postgres_backup_schedule`, `backup_from_primary` is then set to TRUE by default. If the user answers "no" to WAL-E backups, the environment variable `USE_WAL_E_BACKUPS` will be set to "#" and will comment out the code for WAL-E in the `kobo-env/postgres/primary/postgres.conf` file, and the environment variable `USE_WAL_E` is set to FALSE.

In the two docker-compose template files for primary and secondary, the environment variable `OVERRIDE_POSTGRES_SETTINGS` is no longer considered, and the volume is mounted by default.