### PR TITLE
Use `tempfile.mkstemp` instead of hardcoded in `/tmp`

### DIFF
--- a/helpers/command.py
+++ b/helpers/command.py
@@ -382,9 +382,11 @@ class Command:
                                 config.get_letsencrypt_repo_path())
 
         if dict_['maintenance_enabled']:
-            CLI.colored_print('Maintenance mode is enabled. To resume '
-                              'normal operation, use `--stop-maintenance`',
-                              CLI.COLOR_INFO)
+            CLI.colored_print(
+                'Maintenance mode is enabled. To resume '
+                'normal operation, use `--stop-maintenance`',
+                CLI.COLOR_INFO,
+            )
         elif not frontend_only:
             if not config.multi_servers or config.frontend:
                 CLI.colored_print('Waiting for environment to be ready. '

--- a/helpers/command.py
+++ b/helpers/command.py
@@ -382,9 +382,9 @@ class Command:
                                 config.get_letsencrypt_repo_path())
 
         if dict_['maintenance_enabled']:
-                CLI.colored_print('Maintenance mode is enabled. To resume '
-                                  'normal operation, use `--stop-maintenance`',
-                                  CLI.COLOR_INFO)
+            CLI.colored_print('Maintenance mode is enabled. To resume '
+                              'normal operation, use `--stop-maintenance`',
+                              CLI.COLOR_INFO)
         elif not frontend_only:
             if not config.multi_servers or config.frontend:
                 CLI.colored_print('Waiting for environment to be ready. '

--- a/helpers/setup.py
+++ b/helpers/setup.py
@@ -123,6 +123,8 @@ class Setup:
             start_sentence = '### (BEGIN) KoBoToolbox local routes'
             end_sentence = '### (END) KoBoToolbox local routes'
 
+            _, tmp_file_path = tempfile.mkstemp()
+
             with open('/etc/hosts', 'r') as f:
                 tmp_host = f.read()
 
@@ -155,7 +157,7 @@ class Setup:
                 end_sentence=end_sentence
             )
 
-            with open('/tmp/etchosts', 'w') as f:
+            with open(tmp_file_path, 'w') as f:
                 f.write(tmp_host)
 
             message = (
@@ -176,9 +178,15 @@ class Setup:
             config = Config()
             config.write_config()
 
-            cmd = 'sudo mv /etc/hosts /etc/hosts.old ' \
-                  '&& sudo mv /tmp/etchosts /etc/hosts'
+            cmd = (
+                'sudo cp /etc/hosts /etc/hosts.old '
+                '&& sudo cp {tmp_file_path} /etc/hosts'
+            ).format(tmp_file_path=tmp_file_path)
+
             return_value = os.system(cmd)
+
+            os.unlink(tmp_file_path)
+
             if return_value != 0:
                 sys.exit(1)
 


### PR DESCRIPTION
One more step to support Windows :-) 

The temporary files is now copied over `/etc/hosts` instead of being renamed to `/etc/hosts` (because of an issue on macOS making the entries in `/etc/hosts` being ignored) 