### PR TITLE
uWSGI settings raises a TypeError fix

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -1972,7 +1972,7 @@ class Config(metaclass=Singleton):
                     r'~^\d+$',
                     self.__dict['uwsgi_max_requests'])
 
-                CLI.colored_print('Stop spawning workers if uWSGI memory use ',
+                CLI.colored_print('Stop spawning workers if uWSGI memory use '
                                   'exceeds this many MB: ',
                                   CLI.COLOR_QUESTION)
                 self.__dict['uwsgi_soft_limit'] = CLI.get_response(


### PR DESCRIPTION
## Description

When advanced option are chosen and users want to tweak uWSGI settings, it raised an error and made kobo-install to crash
This PR fixes this problem

## Additional info
No tests are added but we should add one for this.