### PR TITLE
Support KoBoCAT 2.0 ...

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -31,7 +31,7 @@ class Config(metaclass=Singleton):
     DEFAULT_NGINX_PORT = '80'
     DEFAULT_NGINX_HTTPS_PORT = '443'
     KOBO_DOCKER_BRANCH = '2.021.09'
-    KOBO_INSTALL_VERSION = '4.4.3'
+    KOBO_INSTALL_VERSION = '4.4.4'
     MAXIMUM_AWS_CREDENTIAL_ATTEMPTS = 3
 
     def __init__(self):


### PR DESCRIPTION
... and few other improvements when choosing dev mode from advanced options.

- Deactivate SSRF protection when install is local (`Workstation`)
- Activate dev configuration for KoBoCAT and KPI
- Possibility to choose whether Celery should be used or not 

This version of kobo-install is needed to run branch `2767-basic-case-management` of KPI and branch `kpi-2767-basic-case-management` of KoBoCAT. 

Closes #118 