### PR TITLE
Add support for extra custom docker configuration

### DIFF
--- a/helpers/command.py
+++ b/helpers/command.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import os
 import sys
 import time
 import subprocess
@@ -109,6 +109,8 @@ class Command:
                    '-f', 'docker-compose.frontend.yml',
                    '-f', 'docker-compose.frontend.override.yml',
                    '-p', config.get_prefix('frontend')]
+
+        cls.__validate_custom_yml(config, command)
         command.extend(args)
         subprocess.call(command, cwd=dict_['kobodocker_path'])
 
@@ -123,6 +125,7 @@ class Command:
             '-f', 'docker-compose.backend.{}.override.yml'.format(backend_role),
             '-p', config.get_prefix('backend')
         ]
+        cls.__validate_custom_yml(config, command)
         command.extend(args)
         subprocess.call(command, cwd=dict_['kobodocker_path'])
 
@@ -225,31 +228,27 @@ class Command:
         if config.primary_backend or config.secondary_backend:
             backend_role = dict_['backend_server_role']
 
-            backend_command = ['docker-compose',
-                               '-f',
-                               'docker-compose.backend.{}.yml'.format(
-                                   backend_role),
-                               '-f',
-                               'docker-compose.backend.{}.override.yml'.format(
-                                   backend_role),
-                               '-p',
-                               config.get_prefix('backend'),
-                               'logs',
-                               '-f'
-                               ]
-            CLI.run_command(backend_command,
-                            dict_['kobodocker_path'],
-                            True)
+            backend_command = [
+                'docker-compose',
+                '-f', 'docker-compose.backend.{}.yml'.format(backend_role),
+                '-f', 'docker-compose.backend.{}.override.yml'.format(backend_role),
+                '-p', config.get_prefix('backend'),
+                'logs', '-f',
+            ]
+            cls.__validate_custom_yml(config, backend_command)
+            CLI.run_command(backend_command, dict_['kobodocker_path'], True)
 
         if config.frontend:
-            frontend_command = ['docker-compose',
-                                '-f', 'docker-compose.frontend.yml',
-                                '-f', 'docker-compose.frontend.override.yml',
-                                '-p', config.get_prefix('frontend'),
-                                'logs', '-f']
-            CLI.run_command(frontend_command,
-                            dict_['kobodocker_path'],
-                            True)
+            frontend_command = [
+                'docker-compose',
+                '-f', 'docker-compose.frontend.yml',
+                '-f', 'docker-compose.frontend.override.yml',
+                '-p', config.get_prefix('frontend'),
+                'logs', '-f',
+            ]
+
+            cls.__validate_custom_yml(config, frontend_command)
+            CLI.run_command(frontend_command, dict_['kobodocker_path'], True)
 
     @classmethod
     def configure_maintenance(cls):
@@ -270,12 +269,15 @@ class Command:
         config = Config()
         dict_ = config.get_dict()
 
-        nginx_stop_command = ['docker-compose',
-                              '-f', 'docker-compose.frontend.yml',
-                              '-f', 'docker-compose.frontend.override.yml',
-                              '-p', config.get_prefix('frontend'),
-                              'stop', 'nginx']
+        nginx_stop_command = [
+            'docker-compose',
+            '-f', 'docker-compose.frontend.yml',
+            '-f', 'docker-compose.frontend.override.yml',
+            '-p', config.get_prefix('frontend'),
+            'stop', 'nginx',
+        ]
 
+        cls.__validate_custom_yml(config, nginx_stop_command)
         CLI.run_command(nginx_stop_command, dict_['kobodocker_path'])
 
     @classmethod
@@ -283,11 +285,13 @@ class Command:
         config = Config()
         dict_ = config.get_dict()
 
-        frontend_command = ['docker-compose',
-                            '-f', 'docker-compose.maintenance.yml',
-                            '-f', 'docker-compose.maintenance.override.yml',
-                            '-p', config.get_prefix('maintenance'),
-                            'up', '-d']
+        frontend_command = [
+            'docker-compose',
+            '-f', 'docker-compose.maintenance.yml',
+            '-f', 'docker-compose.maintenance.override.yml',
+            '-p', config.get_prefix('maintenance'),
+            'up', '-d',
+        ]
 
         CLI.run_command(frontend_command, dict_['kobodocker_path'])
         CLI.colored_print('Maintenance mode has been started',
@@ -341,15 +345,13 @@ class Command:
 
             backend_command = [
                 'docker-compose',
-                '-f',
-                'docker-compose.backend.{}.yml'.format(backend_role),
-                '-f',
-                'docker-compose.backend.{}.override.yml'.format(backend_role),
-                '-p',
-                config.get_prefix('backend'),
-                'up',
-                '-d'
+                '-f', 'docker-compose.backend.{}.yml'.format(backend_role),
+                '-f', 'docker-compose.backend.{}.override.yml'.format(backend_role),
+                '-p', config.get_prefix('backend'),
+                'up', '-d'
             ]
+
+            cls.__validate_custom_yml(config, backend_command)
             CLI.run_command(backend_command, dict_['kobodocker_path'])
 
         # Start the front-end containers
@@ -359,11 +361,13 @@ class Command:
             # separate databases for KPI and KoBoCAT
             Upgrading.migrate_single_to_two_databases(config)
 
-            frontend_command = ['docker-compose',
-                                '-f', 'docker-compose.frontend.yml',
-                                '-f', 'docker-compose.frontend.override.yml',
-                                '-p', config.get_prefix('frontend'),
-                                'up', '-d']
+            frontend_command = [
+                'docker-compose',
+                '-f', 'docker-compose.frontend.yml',
+                '-f', 'docker-compose.frontend.override.yml',
+                '-p', config.get_prefix('frontend'),
+                'up', '-d',
+            ]
 
             if dict_['maintenance_enabled']:
                 cls.start_maintenance()
@@ -372,12 +376,12 @@ class Command:
                     s for s in config.get_service_names() if s != 'nginx'
                 ])
 
+            cls.__validate_custom_yml(config, frontend_command)
             CLI.run_command(frontend_command, dict_['kobodocker_path'])
 
             # Start reverse proxy if user uses it.
             if config.use_letsencrypt:
-                proxy_command = ['docker-compose',
-                                 'up', '-d']
+                proxy_command = ['docker-compose', 'up', '-d']
                 CLI.run_command(proxy_command,
                                 config.get_letsencrypt_repo_path())
 
@@ -421,32 +425,35 @@ class Command:
                             dict_['kobodocker_path'])
 
             # Shut down front-end containers
-            frontend_command = ['docker-compose',
-                                '-f', 'docker-compose.frontend.yml',
-                                '-f', 'docker-compose.frontend.override.yml',
-                                '-p', config.get_prefix('frontend'),
-                                'down']
+            frontend_command = [
+                'docker-compose',
+                '-f', 'docker-compose.frontend.yml',
+                '-f', 'docker-compose.frontend.override.yml',
+                '-p', config.get_prefix('frontend'),
+                'down',
+            ]
+            cls.__validate_custom_yml(config, frontend_command)
             CLI.run_command(frontend_command, dict_['kobodocker_path'])
 
             # Stop reverse proxy if user uses it.
             if config.use_letsencrypt:
-                proxy_command = ['docker-compose',
-                                 'down']
-                CLI.run_command(proxy_command,
-                                config.get_letsencrypt_repo_path())
+                proxy_command = ['docker-compose', 'down']
+                CLI.run_command(
+                    proxy_command, config.get_letsencrypt_repo_path()
+                )
 
         if not frontend_only and config.backend:
             backend_role = dict_['backend_server_role']
 
             backend_command = [
                 'docker-compose',
-                '-f',
-                'docker-compose.backend.{}.yml'.format(backend_role),
-                '-f',
-                'docker-compose.backend.{}.override.yml'.format(backend_role),
+                '-f', 'docker-compose.backend.{}.yml'.format(backend_role),
+                '-f', 'docker-compose.backend.{}.override.yml'.format(backend_role),
                 '-p', config.get_prefix('backend'),
                 'down'
             ]
+
+            cls.__validate_custom_yml(config, backend_command)
             CLI.run_command(backend_command, dict_['kobodocker_path'])
 
         if output:
@@ -467,17 +474,22 @@ class Command:
                 '-f', 'docker-compose.maintenance.yml',
                 '-f', 'docker-compose.maintenance.override.yml',
                 '-p', config.get_prefix('maintenance'),
-                'down']
+                'down'
+            ]
 
-            CLI.run_command(maintenance_down_command,
-                            dict_['kobodocker_path'])
+            CLI.run_command(maintenance_down_command, dict_['kobodocker_path'])
 
             # Create and start NGINX container
-            frontend_command = ['docker-compose',
-                                '-f', 'docker-compose.frontend.yml',
-                                '-f', 'docker-compose.frontend.override.yml',
-                                '-p', config.get_prefix('frontend'),
-                                'up', '-d', 'nginx']
+            frontend_command = [
+                'docker-compose',
+                '-f', 'docker-compose.frontend.yml',
+                '-f', 'docker-compose.frontend.override.yml',
+                '-p', config.get_prefix('frontend'),
+                'up', '-d',
+                'nginx',
+            ]
+
+            cls.__validate_custom_yml(config, frontend_command)
             CLI.run_command(frontend_command, dict_['kobodocker_path'])
 
             CLI.colored_print('Maintenance mode has been stopped',
@@ -495,3 +507,58 @@ class Command:
             Config.KOBO_INSTALL_VERSION,
             stdout.strip()[0:7],
         ), CLI.COLOR_SUCCESS)
+
+    @staticmethod
+    def __validate_custom_yml(config, command):
+        """
+        Validate whether docker-compose must starts the containers with a user's
+        custom YML file in addition to already existing ones and especially if
+        this file already exists. If it does not, kobo-install is paused until
+        the user resumes it manually.
+
+        If user has chosen to use a custom YML file, it is injected in `command`
+        before being sent to shell.
+        """
+        dict_ = config.get_dict()
+        frontend_command = True
+        # Detect if it's a front-end command or back-end command
+        for part in command:
+            if 'backend' in part:
+                frontend_command = False
+                break
+
+        if frontend_command and dict_['use_frontend_custom_yml']:
+            custom_file = '{}/docker-compose.frontend.custom.yml'.format(
+                dict_['kobodocker_path']
+            )
+            if not os.path.exists(custom_file):
+                message = (
+                    'Please create your custom configuration in\n'
+                    '`{custom_file}`.'
+                ).format(custom_file=custom_file)
+                CLI.framed_print(message, color=CLI.COLOR_INFO, columns=75)
+                input('Press any key when it is done...')
+
+            # Add custom file to docker-compose command
+            command.insert(5, '-f')
+            command.insert(6, 'docker-compose.frontend.custom.yml')
+
+        if not frontend_command and dict_['use_backend_custom_yml']:
+            backend_server_role = dict_['backend_server_role']
+            custom_file = '{}/docker-compose.backend.{}.custom.yml'.format(
+                dict_['kobodocker_path'],
+                backend_server_role
+            )
+            if not os.path.exists(custom_file):
+                message = (
+                    'Please create your custom configuration in\n'
+                    '`{custom_file}`.'
+                ).format(custom_file=custom_file)
+                CLI.framed_print(message, color=CLI.COLOR_INFO, columns=75)
+                input('Press any key when it is done...')
+
+            # Add custom file to docker-compose command
+            command.insert(5, '-f')
+            command.insert(
+                6, 'docker-compose.backend.{}.custom.yml'.format(backend_server_role)
+            )

--- a/helpers/command.py
+++ b/helpers/command.py
@@ -511,13 +511,12 @@ class Command:
     @staticmethod
     def __validate_custom_yml(config, command):
         """
-        Validate whether docker-compose must starts the containers with a user's
-        custom YML file in addition to already existing ones and especially if
-        this file already exists. If it does not, kobo-install is paused until
-        the user resumes it manually.
+        Validate whether docker-compose must start the containers with a
+        custom YML file in addition to the default. If the file does not yet exist,
+        kobo-install is paused until the user creates it and resumes the setup manually.
 
-        If user has chosen to use a custom YML file, it is injected in `command`
-        before being sent to shell.
+        If user has chosen to use a custom YML file, it is injected into `command`
+        before being executed.
         """
         dict_ = config.get_dict()
         frontend_command = True
@@ -531,13 +530,16 @@ class Command:
             custom_file = '{}/docker-compose.frontend.custom.yml'.format(
                 dict_['kobodocker_path']
             )
-            if not os.path.exists(custom_file):
+
+            does_custom_file_exist = os.path.exists(custom_file)
+            while not does_custom_file_exist:
                 message = (
                     'Please create your custom configuration in\n'
                     '`{custom_file}`.'
                 ).format(custom_file=custom_file)
-                CLI.framed_print(message, color=CLI.COLOR_INFO, columns=75)
+                CLI.framed_print(message, color=CLI.COLOR_INFO, columns=90)
                 input('Press any key when it is done...')
+                does_custom_file_exist = os.path.exists(custom_file)
 
             # Add custom file to docker-compose command
             command.insert(5, '-f')
@@ -549,13 +551,17 @@ class Command:
                 dict_['kobodocker_path'],
                 backend_server_role
             )
-            if not os.path.exists(custom_file):
+
+            does_custom_file_exist = os.path.exists(custom_file)
+            while not does_custom_file_exist:
                 message = (
                     'Please create your custom configuration in\n'
                     '`{custom_file}`.'
                 ).format(custom_file=custom_file)
-                CLI.framed_print(message, color=CLI.COLOR_INFO, columns=75)
+                CLI.framed_print(message, color=CLI.COLOR_INFO, columns=90)
                 input('Press any key when it is done...')
+                does_custom_file_exist = os.path.exists(custom_file)
+
 
             # Add custom file to docker-compose command
             command.insert(5, '-f')

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -31,7 +31,7 @@ class Config(metaclass=Singleton):
     DEFAULT_NGINX_PORT = '80'
     DEFAULT_NGINX_HTTPS_PORT = '443'
     KOBO_DOCKER_BRANCH = 'beta'
-    KOBO_INSTALL_VERSION = '6.1.0'
+    KOBO_INSTALL_VERSION = '6.2.0'
     MAXIMUM_AWS_CREDENTIAL_ATTEMPTS = 3
 
     def __init__(self):
@@ -76,8 +76,7 @@ class Config(metaclass=Singleton):
 
     @property
     def backend(self):
-        return not self.multi_servers or self.primary_backend or \
-               self.secondary_backend
+        return not self.multi_servers or not self.frontend
 
     @property
     def block_common_http_ports(self):
@@ -154,16 +153,6 @@ class Config(metaclass=Singleton):
 
         return upgraded_dict
 
-    @property
-    def backend_questions(self):
-        """
-        Checks whether questions are back end only
-
-        Returns:
-            bool
-        """
-        return not self.multi_servers or not self.frontend
-
     def build(self):
         """
         Build configuration based on user's answers
@@ -199,12 +188,12 @@ class Config(metaclass=Singleton):
                     else:
                         self.__reset(fake_dns=True)
 
-                if self.frontend_questions:
+                if self.frontend:
                     self.__questions_public_routes()
                     self.__questions_https()
                     self.__questions_reverse_proxy()
 
-            if self.frontend_questions:
+            if self.frontend:
                 self.__questions_smtp()
                 self.__questions_super_user_credentials()
 
@@ -216,12 +205,15 @@ class Config(metaclass=Singleton):
                 self.__questions_redis()
                 self.__questions_ports()
 
-                if self.frontend_questions:
+                if self.frontend:
                     self.__questions_secret_keys()
                     self.__questions_aws()
                     self.__questions_google()
                     self.__questions_raven()
                     self.__questions_uwsgi()
+
+                self.__questions_custom_yml()
+
             else:
                 self.__secure_mongo()
 
@@ -256,18 +248,9 @@ class Config(metaclass=Singleton):
             dict: all values from user's responses needed to create
             configuration files
         """
-        return not self.multi_servers or \
-            self.__dict['server_role'] == 'frontend'
-
-    @property
-    def frontend_questions(self):
-        """
-        Checks whether questions are front-end only
-
-        Returns:
-            bool
-        """
-        return not self.multi_servers or self.frontend
+        return (
+            not self.multi_servers or self.__dict['server_role'] == 'frontend'
+        )
 
     @classmethod
     def generate_password(cls):
@@ -431,7 +414,9 @@ class Config(metaclass=Singleton):
             'two_databases': True,
             'use_aws': False,
             'use_backup': False,
+            'use_backend_custom_yml': False,
             'use_celery': True,
+            'use_frontend_custom_yml': False,
             'use_letsencrypt': True,
             'use_private_dns': False,
             'use_wal_e': False,
@@ -927,7 +912,7 @@ class Config(metaclass=Singleton):
         """
         Asks all questions about backups.
         """
-        if self.backend_questions or (self.frontend_questions and not self.aws):
+        if self.backend or (self.frontend and not self.aws):
 
             self.__dict['use_backup'] = CLI.yes_no_question(
                 'Do you want to activate backups?',
@@ -936,7 +921,7 @@ class Config(metaclass=Singleton):
 
             if self.__dict['use_backup']:
                 if self.advanced_options:
-                    if self.backend_questions and not self.frontend_questions:
+                    if self.backend and not self.frontend:
                         self.__questions_aws()
 
                     # Prompting user whether they want to use WAL-E for
@@ -972,7 +957,7 @@ class Config(metaclass=Singleton):
                     )
                     CLI.framed_print(message, color=CLI.COLOR_INFO)
 
-                    if self.frontend_questions and not self.aws:
+                    if self.frontend and not self.aws:
                         CLI.colored_print('KoBoCat media backup schedule?',
                                           CLI.COLOR_QUESTION)
                         self.__dict[
@@ -980,7 +965,7 @@ class Config(metaclass=Singleton):
                             '~{}'.format(schedule_regex_pattern),
                             self.__dict['kobocat_media_backup_schedule'])
 
-                    if self.backend_questions:
+                    if self.backend:
                         if self.__dict['use_wal_e'] is True:
                             self.__dict['backup_from_primary'] = True
                         else:
@@ -1035,6 +1020,22 @@ class Config(metaclass=Singleton):
         else:
             self.__reset(no_backups=True)
 
+    def __questions_custom_yml(self):
+
+        if self.frontend:
+            self.__dict['use_frontend_custom_yml'] = CLI.yes_no_question(
+                'Do you want to add additional settings to the front-end '
+                'docker containers?',
+                default=self.__dict['use_frontend_custom_yml'],
+            )
+
+        if self.backend:
+            self.__dict['use_backend_custom_yml'] = CLI.yes_no_question(
+                'Do you want to add additional settings to the backend-end '
+                'docker containers?',
+                default=self.__dict['use_backend_custom_yml']
+            )
+
     def __questions_dev_mode(self):
         """
         Asks for developer/staging mode.
@@ -1045,7 +1046,7 @@ class Config(metaclass=Singleton):
         Reset to default in case of No
         """
 
-        if self.frontend_questions:
+        if self.frontend:
 
             if self.local_install:
                 # NGINX different port
@@ -1447,7 +1448,7 @@ class Config(metaclass=Singleton):
 
             self.__write_upsert_db_users_trigger_file(content, 'postgres')
 
-        if self.backend_questions:
+        if self.backend:
             # Postgres settings
             self.__dict['postgres_settings'] = CLI.yes_no_question(
                 'Do you want to tweak PostgreSQL settings?',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,8 +116,8 @@ def test_dev_mode():
 
 def test_server_roles_questions():
     config = read_config()
-    assert config.frontend_questions
-    assert config.backend_questions
+    assert config.frontend
+    assert config.backend
 
     with patch('helpers.cli.CLI.colored_input') as mock_colored_input:
         mock_colored_input.side_effect = iter(
@@ -126,12 +126,12 @@ def test_server_roles_questions():
         config._Config__questions_multi_servers()
 
         config._Config__questions_roles()
-        assert config.frontend_questions
-        assert not config.backend_questions
+        assert config.frontend
+        assert not config.backend
 
         config._Config__questions_roles()
-        assert not config.frontend_questions
-        assert config.backend_questions
+        assert not config.frontend
+        assert config.backend
         assert config.secondary_backend
 
 


### PR DESCRIPTION
Sometimes for custom install, some variables or configurations may be needed to be passed docker containers.
All custom configuration added to `*.override.yml` are lost upgrade or when setup is run.
This version lets users add another file to `kobo-docker` folder to persist any custom configurations. 



