### PR TITLE
Keep Python 3.5 retro-compatibility

### DIFF
--- a/helpers/aws_validation.py
+++ b/helpers/aws_validation.py
@@ -48,7 +48,11 @@ class AWSValidation:
         canonical_querystring = self.REQUEST_PARAMETERS
 
         canonical_headers = '\n'.join(
-            [f'host:{self.HOST}', f'x-amz-date:{amzdate}', '']
+            [
+                'host:{host}'.format(host=self.HOST),
+                'x-amz-date:{amzdate}'.format(amzdate=amzdate),
+                '',
+            ]
         )
 
         canonical_request = '\n'.join(

--- a/helpers/command.py
+++ b/helpers/command.py
@@ -562,7 +562,6 @@ class Command:
                 input('Press any key when it is done...')
                 does_custom_file_exist = os.path.exists(custom_file)
 
-
             # Add custom file to docker-compose command
             command.insert(5, '-f')
             command.insert(


### PR DESCRIPTION
We still support Python 3.5 (not for long though). `f-strings` cannot use with it.