### PR TITLE
Do not move "kobo-deployments" if "kobo-env" already exists

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -170,7 +170,7 @@ class Config(metaclass=Singleton):
         )))
 
         # if old location is detected, move it to new path.
-        if os.path.exists(old_path):
+        if os.path.exists(old_path) and not os.path.exists(current_path):
             shutil.move(old_path, current_path)
 
         return current_path


### PR DESCRIPTION
Environment variables used to be saved in `kobo-deployments` folder. 
There are now saved inside `kobo-env` folder. 
`shutil.move` moves `kobo-deployments` inside `kobo-env` instead of renaming it when it already exists.

kobo-install should move old folder to new one on upgrade but only when the new folder does not exist. 
