### PR TITLE
Replace instances of "KoBoToolbox" with "KoboToolbox"

### DIFF
--- a/helpers/command.py
+++ b/helpers/command.py
@@ -20,7 +20,7 @@ class Command:
             '',
             '    Options:',
             '          -i, --info',
-            '                Show KoBoToolbox Url and super user credentials',
+            '                Show KoboToolbox Url and super user credentials',
             '          -l, --logs',
             '                Display docker logs',
             '          -b, --build',
@@ -32,9 +32,9 @@ class Command:
             '          -s, --setup',
             '                Prompt questions to (re)write configuration files',
             '          -S, --stop',
-            '                Stop KoBoToolbox',
+            '                Stop KoboToolbox',
             '          -u, --update, --upgrade [branch or tag]',
-            '                Update KoBoToolbox',
+            '                Update KoboToolbox',
             '          -cf, --compose-frontend [docker-compose arguments]',
             '                Run a docker-compose command in the front-end '
             'environment',
@@ -462,7 +462,7 @@ class Command:
             CLI.run_command(backend_command, dict_['kobodocker_path'])
 
         if output:
-            CLI.colored_print('KoBoToolbox has been stopped', CLI.COLOR_SUCCESS)
+            CLI.colored_print('KoboToolbox has been stopped', CLI.COLOR_SUCCESS)
 
     @classmethod
     def stop_maintenance(cls):

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -2076,7 +2076,7 @@ class Config(metaclass=Singleton):
             message = (
                 'WARNING!\n\n'
                 'You have configured a new password for the super user.\n'
-                'This change will *not* take effect if KoBoToolbox has ever '
+                'This change will *not* take effect if KoboToolbox has ever '
                 'been started before. Please use the web interface to change '
                 'passwords for existing users.\n'
                 'If you have forgotten your password:\n'
@@ -2272,7 +2272,7 @@ class Config(metaclass=Singleton):
             'Welcome to kobo-install.\n'
             '\n'
             'You are going to be asked some questions that will determine how '
-            'to build the configuration of `KoBoToolBox`.\n'
+            'to build the configuration of `KoboToolBox`.\n'
             '\n'
             'Some questions already have default values (within brackets).\n'
             'Just press `enter` to accept the default value or enter `-` to '

--- a/helpers/setup.py
+++ b/helpers/setup.py
@@ -119,16 +119,16 @@ class Setup:
             dict_ (dict): Dictionary provided by `Config.get_dict()`
         """
         if dict_['local_installation']:
-            start_sentence = '### (BEGIN) KoBoToolbox local routes'
-            end_sentence = '### (END) KoBoToolbox local routes'
+            start_sentence = '### (BEGIN) KoboToolbox local routes'
+            end_sentence = '### (END) KoboToolbox local routes'
 
             _, tmp_file_path = tempfile.mkstemp()
 
             with open('/etc/hosts', 'r') as f:
                 tmp_host = f.read()
 
-            start_position = tmp_host.find(start_sentence)
-            end_position = tmp_host.find(end_sentence)
+            start_position = tmp_host.lower().find(start_sentence.lower())
+            end_position = tmp_host.lower().find(end_sentence.lower())
 
             if start_position > -1:
                 tmp_host = tmp_host[0: start_position] \

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     url='https://github.com/kobotoolbox/kobo-install/',
     license='',
-    author='KoBoToolbox',
+    author='KoboToolbox',
     author_email='',
-    description='Installer for KoBoToolbox'
+    description='Installer for KoboToolbox'
 )

--- a/templates/kobo-env/enketo_express/config.json.tpl
+++ b/templates/kobo-env/enketo_express/config.json.tpl
@@ -1,7 +1,7 @@
 {
-    "app name": "Enketo Express for KoBo Toolbox",
+    "app name": "Enketo Express for KoboToolbox",
     "linked form and data server": {
-        "name": "KoBo Toolbox",
+        "name": "KoboToolbox",
         "server url": "",
         "api key": "${ENKETO_API_KEY}"
     },


### PR DESCRIPTION
## Description

Use consistent spelling of "KoboToolbox" and "Kobo" in the UI.

## Related issues

Related to kobotoolbox/kpi#3637