### PR TITLE
Fixes intermittent 504 timeouts with default uWSGI settings

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -421,12 +421,12 @@ class Config(metaclass=Singleton):
             'use_private_dns': False,
             'use_wal_e': False,
             'uwsgi_harakiri': '120',
-            'uwsgi_max_requests': '512',
+            'uwsgi_max_requests': '1024',
             'uwsgi_settings': False,
-            'uwsgi_soft_limit': '128',
+            'uwsgi_soft_limit': '1024',
             'uwsgi_worker_reload_mercy': '120',
-            'uwsgi_workers_max': '2',
-            'uwsgi_workers_start': '1',
+            'uwsgi_workers_max': '4',
+            'uwsgi_workers_start': '2',
         }
 
     @property
@@ -2137,10 +2137,10 @@ class Config(metaclass=Singleton):
 
                 return
 
-        self.__dict['uwsgi_workers_start'] = '1'
-        self.__dict['uwsgi_workers_max'] = '2'
-        self.__dict['uwsgi_max_requests'] = '512'
-        self.__dict['uwsgi_soft_limit'] = '128'
+        self.__dict['uwsgi_workers_start'] = '2'
+        self.__dict['uwsgi_workers_max'] = '4'
+        self.__dict['uwsgi_max_requests'] = '1024'
+        self.__dict['uwsgi_soft_limit'] = '1024'
         self.__dict['uwsgi_harakiri'] = '120'
         self.__dict['uwsgi_worker_reload_mercy'] = '120'
 

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -208,7 +208,13 @@ class Template:
             'NGINX_PUBLIC_PORT': dict_['exposed_nginx_docker_port'],
             'NGINX_EXPOSED_PORT': nginx_port,
             'UWSGI_WORKERS_MAX': dict_['uwsgi_workers_max'],
-            'UWSGI_WORKERS_START': dict_['uwsgi_workers_start'],
+            # Deactivate cheaper algorithm if defaults are 1 worker to start and
+            # 2 maximum.
+            'UWSGI_WORKERS_START': (
+                ''
+                if dict_['uwsgi_workers_start'] == '1' and dict_['uwsgi_workers_max'] == '2'
+                else dict_['uwsgi_workers_start']
+            ),
             'UWSGI_MAX_REQUESTS': dict_['uwsgi_max_requests'],
             'UWSGI_SOFT_LIMIT': int(
                 dict_['uwsgi_soft_limit']) * 1024 * 1024,


### PR DESCRIPTION
## Description
Fixes KoBoCAT random locks when no apparent errors are present in the logs

## Additional info
- Bump the number of uWSGi workers to serve requests from min:1, max:2 to min:2, max:4
- Increase the memory soft limit from 128 MB to 512 MB
- Deactivate `cheaper` algorithm when min is still equal to 1 and max is still equal to 2

## Related issues
Closes #160 