### PR TITLE
Add support to Docker Compose v2

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -16,6 +16,7 @@ from helpers.cli import CLI
 from helpers.network import Network
 from helpers.singleton import Singleton
 from helpers.upgrading import Upgrading
+from helpers.utils import run_docker_compose
 
 
 # Use this class as a singleton to get the same configuration
@@ -226,6 +227,8 @@ class Config(metaclass=Singleton):
         # Upgrade to use booleans in `self.__dict`
         upgraded_dict = Upgrading.use_booleans(upgraded_dict)
 
+        upgraded_dict = Upgrading.set_compose_version(upgraded_dict)
+
         return upgraded_dict
 
     @property
@@ -274,13 +277,15 @@ class Config(metaclass=Singleton):
         return self.__dict
 
     def get_service_names(self):
-        service_list_command = ['docker-compose',
-                                '-f', 'docker-compose.frontend.yml',
-                                '-f', 'docker-compose.frontend.override.yml',
-                                'config', '--services']
+        service_list_command = run_docker_compose(self.__dict, [
+            '-f', 'docker-compose.frontend.yml',
+            '-f', 'docker-compose.frontend.override.yml',
+            'config', '--services',
+        ])
 
-        services = CLI.run_command(service_list_command,
-                                   self.__dict['kobodocker_path'])
+        services = CLI.run_command(
+            service_list_command, self.__dict['kobodocker_path']
+        )
         return services.strip().split('\n')
 
     @classmethod

--- a/helpers/upgrading.py
+++ b/helpers/upgrading.py
@@ -149,17 +149,12 @@ class Upgrading:
 
     @staticmethod
     def set_compose_version(upgraded_dict: dict) -> dict:
-        try:
-            upgraded_dict['compose_version']
-        except KeyError:
+
+        if 'compose_version' not in upgraded_dict:
             # FIXME On macOS, Docker Desktop always installs a symlink for
             #   `docker-compose`. Version will be always detected as v1 even if
             #   user has chosen v2 in Docker Desktop preferences.
-            if which('docker-compose') is None:
-                compose_version = 'v2'
-            else:
-                compose_version = 'v1'
-
+            compose_version = 'v2' if which('docker-compose') is None else 'v1'
             upgraded_dict['compose_version'] = compose_version
 
         return upgraded_dict

--- a/helpers/upgrading.py
+++ b/helpers/upgrading.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import subprocess
 import sys
+from shutil import which
 
 from helpers.cli import CLI
+from helpers.utils import run_docker_compose
 
 
 class Upgrading:
 
     @staticmethod
-    def migrate_single_to_two_databases(config):
+    def migrate_single_to_two_databases(config: 'helpers.Config'):
         """
         Check the contents of the databases. If KPI's is empty or doesn't exist
         while KoBoCAT's has user data, then we are migrating from a
@@ -28,11 +32,12 @@ class Upgrading:
             set_env = 'DATABASE_URL="${KPI_DATABASE_URL}"'
             return ['bash', '-c', f'{set_env} {command}']
 
-        kpi_run_command = ['docker-compose',
-                           '-f', 'docker-compose.frontend.yml',
-                           '-f', 'docker-compose.frontend.override.yml',
-                           '-p', config.get_prefix('frontend'),
-                           'run', '--rm', 'kpi']
+        kpi_run_command = run_docker_compose(dict_, [
+           '-f', 'docker-compose.frontend.yml',
+           '-f', 'docker-compose.frontend.override.yml',
+           '-p', config.get_prefix('frontend'),
+           'run', '--rm', 'kpi'
+        ])
 
         # Make sure Postgres is running
         # We add this message to users because when AWS backups are activated,
@@ -96,17 +101,14 @@ class Upgrading:
             if response is False:
                 sys.exit(0)
 
-            backend_command = [
-                'docker-compose',
-                '-f',
-                f'docker-compose.backend.{backend_role}.yml',
-                '-f',
-                f'docker-compose.backend.{backend_role}.override.yml',
+            backend_command = run_docker_compose(dict_, [
+                '-f', f'docker-compose.backend.{backend_role}.yml',
+                '-f', f'docker-compose.backend.{backend_role}.override.yml',
                 '-p', config.get_prefix('backend'),
                 'exec', 'postgres', 'bash',
                 '/kobo-docker-scripts/primary/clone_data_from_kc_to_kpi.sh',
                 '--noinput'
-            ]
+            ])
             try:
                 subprocess.check_call(
                     backend_command, cwd=dict_['kobodocker_path']
@@ -126,7 +128,7 @@ class Upgrading:
             sys.exit(1)
 
     @staticmethod
-    def new_terminology(upgraded_dict):
+    def new_terminology(upgraded_dict: dict) -> dict:
         """
         Updates configuration to use new `kobo-docker` terminology.
         See: https://github.com/kobotoolbox/kobo-docker/pull/294
@@ -146,7 +148,24 @@ class Upgrading:
         return upgraded_dict
 
     @staticmethod
-    def two_databases(upgraded_dict, current_dict):
+    def set_compose_version(upgraded_dict: dict) -> dict:
+        try:
+            upgraded_dict['compose_version']
+        except KeyError:
+            # FIXME On macOS, Docker Desktop always installs a symlink for
+            #   `docker-compose`. Version will be always detected as v1 even if
+            #   user has chosen v2 in Docker Desktop preferences.
+            if which('docker-compose') is None:
+                compose_version = 'v2'
+            else:
+                compose_version = 'v1'
+
+            upgraded_dict['compose_version'] = compose_version
+
+        return upgraded_dict
+
+    @staticmethod
+    def two_databases(upgraded_dict: dict, current_dict: dict) -> dict:
         """
         If the configuration came from a previous version that had a single
         Postgres database, we need to make sure the new `kc_postgres_db` is
@@ -182,7 +201,7 @@ class Upgrading:
         return upgraded_dict
 
     @staticmethod
-    def use_booleans(upgraded_dict):
+    def use_booleans(upgraded_dict: dict) -> dict:
         """
         Until version 3.x, two constants (`Config.TRUE` and `Config.FALSE`) were
         used to store "Yes/No"  users' responses. It made the code more

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def run_docker_compose(config_dict: dict, command: list[str]) -> list[str]:
+
+    try:
+        compose_version = config_dict['compose_version']
+    except KeyError:
+        # Consider version as v1. If 'compose_version' key is missing, it is
+        # probably because user has pulled kobo-install without running `--update`
+        compose_version = 'v1'
+
+    if compose_version == 'v1':
+        return ['docker-compose'] + command
+    else:
+        return ['docker', 'compose'] + command

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 
 def run_docker_compose(config_dict: dict, command: list[str]) -> list[str]:
 
-    try:
-        compose_version = config_dict['compose_version']
-    except KeyError:
-        # Consider version as v1. If 'compose_version' key is missing, it is
-        # probably because user has pulled kobo-install without running `--update`
-        compose_version = 'v1'
+    # Consider version as v1 if 'compose_version' key is missing. It is
+    # probably because user has [git] pulled kobo-install without running `--update`
+    compose_version = config_dict.get('compose_version', 'v1')
 
     if compose_version == 'v1':
         return ['docker-compose'] + command


### PR DESCRIPTION
# Description
kobo-install uses compatible command for `docker-compose` (v1) and `docker compose` (v2). 
It detects if `docker-compose` is present on the system. Otherwise, it falls back to `docker compose`.

## Additional info
On macOS. Docker Desktop creates a symlink on `docker-compose` then runs `docker compose` behind the scene. 
kobo-install will see at v1 even v2 is checked in preferences. But it does not matter, it still works that way. (tested with Docker Desktop for mac `4.14.0` and Compose: `v2.12.2`).