### PR TITLE
Python 3.7+ is required

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ User can choose between 2 types of installations:
 ## Requirements
 
 - Linux <sup>5</sup> / macOS <sup>6</sup>
-- Python 3.6+
+- Python 3.7+
 - [Docker](https://www.docker.com/get-started "") & [Docker Compose](https://docs.docker.com/compose/install/ "")
 - Available TCP Ports: <sup>7</sup>
 


### PR DESCRIPTION
Attempts to run run.py in Python 3.6 fail due to incorrect syntax: python future feature annotations is not defined. This feature was added only in python 3.7: https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations
@noliveleger 