### PR TITLE
Avoid broadcast address when using UDP connect…

### DIFF
--- a/helpers/network.py
+++ b/helpers/network.py
@@ -137,7 +137,10 @@ class Network:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
             # doesn't even have to be reachable
-            s.connect(('10.255.255.255', 1))
+            # …but it can't be a broadcast address, or you'll get
+            # `Permission denied`. See recent comments on the same SO answer:
+            # https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib/28950776#comment128390746_28950776
+            s.connect(('10.255.255.254', 1))
             ip_address = s.getsockname()[0]
         except:
             ip_address = None


### PR DESCRIPTION
trick to ascertain local IP address. Avoids "No valid networks detected", caused by an underlying `PermissionError` raised by the `connect()` call, when the host machine has an IP address on a subnet where 10.255.255.255 is the broadcast address.

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/kobo-install.20questions.20and.20problems/near/203932