### PR TITLE
Add compose v2 support to letsencrypt init script

### DIFF
--- a/helpers/command.py
+++ b/helpers/command.py
@@ -374,10 +374,11 @@ class Command:
                     # Let's Encrypt NGINX container needs kobo-docker NGINX
                     # container to be started first
                     config.init_letsencrypt()
-                else:
-                    proxy_command = run_docker_compose(dict_, ['up', '-d'])
-                    CLI.run_command(proxy_command,
-                                    config.get_letsencrypt_repo_path())
+
+                proxy_command = run_docker_compose(dict_, ['up', '-d'])
+                CLI.run_command(
+                    proxy_command, config.get_letsencrypt_repo_path()
+                )
 
         if dict_['maintenance_enabled']:
             CLI.colored_print(

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -317,6 +317,13 @@ class Template:
                 if config.local_install
                 else _get_value('service_account_whitelisted_hosts')
             ),
+            'DOCKER_COMPOSE_CMD': _get_value(
+                'compose_version', 'docker-compose', 'docker', 'v1'
+            ),
+            # Keep leading space in front of suffix if any
+            'DOCKER_COMPOSE_SUFFIX': _get_value(
+                'compose_version', '', ' compose', 'v1'
+            )
         }
 
     @staticmethod

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -322,7 +322,7 @@ class Template:
             ),
             # Keep leading space in front of suffix if any
             'DOCKER_COMPOSE_SUFFIX': _get_value(
-                'compose_version', '', ' compose', 'v1'
+                'compose_version', '', 'compose', 'v1'
             )
         }
 

--- a/readme.md
+++ b/readme.md
@@ -147,9 +147,9 @@ User can choose between 2 types of installations:
 ## Requirements
 
 - Linux <sup>5</sup> / macOS <sup>6</sup>
-- Python 3.7+
-- [Docker](https://www.docker.com/get-started "") & [Docker Compose](https://docs.docker.com/compose/install/ "")
-- Available TCP Ports: <sup>7</sup>
+- Python 3.8+
+- [Docker](https://www.docker.com/get-started "") <sup>7</sup>
+- Available TCP Ports: <sup>8</sup>
 
     1. 80 NGINX
     1. 443 NGINX (if you use kobo-install with LetsEncrypt proxy)
@@ -163,11 +163,13 @@ User can choose between 2 types of installations:
     - _If you use a firewall, be sure to open traffic publicly on NGINX port, otherwise kobo-install cannot work_
     - _By default, additional ports are not exposed except when using multi servers configuration. If you choose to expose them, **be sure to not expose them publicly** (e.g. use a firewall and allow traffic between front-end and back-end containers only. NGINX port still has to stay publicly opened though)._
 
-<sup>5)</sup> _It has been tested with Ubuntu 14.04, 16.04 and 18.04, CentOS 8_
+<sup>5)</sup> _It has been tested with Ubuntu 18.04, 20.04 and 22.04_
 
 <sup>6)</sup> _Docker on macOS is slow. First boot usually takes a while to be ready. You may have to answer `Yes` once or twice to question `Wait for another 600 seconds?` when prompted_
 
-<sup>7)</sup> _These are defaults but can be customized with advanced options_
+<sup>7)</sup> _Compose V1 is still supported but reached its EOL_
+
+<sup>8)</sup> _These are defaults but can be customized with advanced options_
 
 
 ## Tests

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ User can choose between 2 types of installations:
 
 <sup>6)</sup> _Docker on macOS is slow. First boot usually takes a while to be ready. You may have to answer `Yes` once or twice to question `Wait for another 600 seconds?` when prompted_
 
-<sup>7)</sup> _Compose V1 is still supported but reached its EOL_
+<sup>7)</sup> _Compose V1 is still supported but has reached its EOL from July 2023_
 
 <sup>8)</sup> _These are defaults but can be customized with advanced options_
 

--- a/templates/nginx-certbot/init-letsencrypt.sh.tpl
+++ b/templates/nginx-certbot/init-letsencrypt.sh.tpl
@@ -9,7 +9,7 @@ DATA_PATH="./data/certbot"
 EMAIL="" # Adding a valid address is strongly recommended
 STAGING=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 MKDIR_CMD=$$(which mkdir)
-DOCKER_COMPOSE_CMD=$$(which docker-compose)
+DOCKER_COMPOSE_CMD="$$(which ${DOCKER_COMPOSE_CMD})"
 CURL_CMD=$$(which curl)
 
 
@@ -31,7 +31,7 @@ fi
 echo "### Creating dummy certificate for $${DOMAINS_CSV} ..."
 DOMAINS_PATH="/etc/letsencrypt/live/$$DOMAINS"
 $$MKDIR_CMD -p "$$DATA_PATH/conf/live/$$DOMAINS"
-$$DOCKER_COMPOSE_CMD run --rm --entrypoint "\
+$$DOCKER_COMPOSE_CMD ${DOCKER_COMPOSE_SUFFIX} run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:1024 -days 1\
     -keyout '$$DOMAINS_PATH/privkey.pem' \
     -out '$$DOMAINS_PATH/fullchain.pem' \
@@ -40,11 +40,11 @@ echo
 
 
 echo "### Starting nginx ..."
-$$DOCKER_COMPOSE_CMD up --force-recreate -d nginx_ssl_proxy
+$$DOCKER_COMPOSE_CMD ${DOCKER_COMPOSE_SUFFIX} up --force-recreate -d nginx_ssl_proxy
 echo
 
 echo "### Deleting dummy certificate for $${DOMAINS_CSV} ..."
-$$DOCKER_COMPOSE_CMD run --rm --entrypoint "\
+$$DOCKER_COMPOSE_CMD ${DOCKER_COMPOSE_SUFFIX} run --rm --entrypoint "\
   rm -Rf /etc/letsencrypt/live/$$DOMAINS && \
   rm -Rf /etc/letsencrypt/archive/$$DOMAINS && \
   rm -Rf /etc/letsencrypt/renewal/$$DOMAINS.conf" certbot
@@ -67,7 +67,7 @@ esac
 # Enable staging mode if needed
 if [ $$STAGING != "0" ]; then STAGING_ARG="--staging"; fi
 
-$$DOCKER_COMPOSE_CMD run --rm --entrypoint "\
+$$DOCKER_COMPOSE_CMD ${DOCKER_COMPOSE_SUFFIX} run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \
     $$STAGING_ARG \
     $$EMAIL_ARG \
@@ -78,4 +78,4 @@ $$DOCKER_COMPOSE_CMD run --rm --entrypoint "\
 echo
 
 echo "### Reloading nginx ..."
-$$DOCKER_COMPOSE_CMD exec nginx_ssl_proxy nginx -s reload
+$$DOCKER_COMPOSE_CMD ${DOCKER_COMPOSE_SUFFIX} exec nginx_ssl_proxy nginx -s reload

--- a/templates/nginx-certbot/init-letsencrypt.sh.tpl
+++ b/templates/nginx-certbot/init-letsencrypt.sh.tpl
@@ -13,7 +13,7 @@ DOCKER_COMPOSE_CMD="$$(which ${DOCKER_COMPOSE_CMD})"
 CURL_CMD=$$(which curl)
 
 
-if [ -d "$$DATA_PATH" ]; then
+if [ -d "$$DATA_PATH/conf/live/$$DOMAINS" ]; then
   read -p "Existing data found for $$DOMAINS_CSV. Continue and replace existing certificate? (y/N) " decision
   if [ "$$decision" != "Y" ] && [ "$$decision" != "y" ]; then
     exit


### PR DESCRIPTION
## Description

kobo-install can detect which version of compose is used and builds the LetsEncrypt init script accordingly (instead of using a hard-coded command (i.e.: `docker-compose`) 

## Notes 
README has been also updated. It closes #223

## Related Issues
Fixes #230 
Closes #186
