### PR TITLE
Fix: network selection changing interface name to lowercase

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -812,7 +812,8 @@ class Config(metaclass=Singleton):
             choices.append('other')
             response = CLI.get_response(
                 choices,
-                default=self.__dict['local_interface']
+                default=self.__dict['local_interface'],
+                to_lower=False
             )
 
             if response == 'other':


### PR DESCRIPTION
### Issue
The installation fails on ubuntu 24 with default network interface name as *enX0* fails as the installation `run.py` triggering `CLI.get_response()` converts the input to lowercase and changes it to *enx0*.

This issue triggers KeyError during installation setup.

<img width="1440" alt="Screenshot 2024-06-11 at 11 03 45" src="https://github.com/kobotoolbox/kobo-install/assets/39024181/f173e83c-76b8-4b91-b03b-b390d8873440">


## Fix
Added to_lower parameter in \
`CLI.get_response(...., to_lower=False)`
