### PR TITLE
build: ignore kobo-env default path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 .pytest_cache/
 .tox
 *.egg-info
+
+/kobo-env/


### PR DESCRIPTION
git-ignore kobo-env at it's default path, because it's not part of a kobo-install repo.
