### PR TITLE
Adjustment of templates for nginx-certbot

### DIFF
--- a/templates/nginx-certbot/docker-compose.yml.tpl
+++ b/templates/nginx-certbot/docker-compose.yml.tpl
@@ -25,3 +25,4 @@ services:
 networks:
   kobo-fe-network:
     name: ${DOCKER_NETWORK_FRONTEND_PREFIX}_kobo-fe-network
+    external: true

--- a/templates/nginx-certbot/init-letsencrypt.sh.tpl
+++ b/templates/nginx-certbot/init-letsencrypt.sh.tpl
@@ -32,7 +32,7 @@ echo "### Creating dummy certificate for $${DOMAINS_CSV} ..."
 DOMAINS_PATH="/etc/letsencrypt/live/$$DOMAINS"
 $$MKDIR_CMD -p "$$DATA_PATH/conf/live/$$DOMAINS"
 $$DOCKER_COMPOSE_CMD ${DOCKER_COMPOSE_SUFFIX} run --rm --entrypoint "\
-  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+  openssl req -x509 -nodes -newkey rsa:2048 -days 1\
     -keyout '$$DOMAINS_PATH/privkey.pem' \
     -out '$$DOMAINS_PATH/fullchain.pem' \
     -subj '/CN=localhost'" certbot


### PR DESCRIPTION
While setting up KoboToolbox using kobo-install, small adjustments to the templates of the nginx-cerbot are needed for succesfully installing the software:

1. Increasing the RSA key size for generating dummy certificates on environments with Python 3.10+
2. Marking the kobe-fe-network as 'external'