### PR TITLE
chore: replace tox with pytest, upgrade to Python 3.12

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ User can choose between 2 types of installations:
 ## Requirements
 
 - Linux <sup>5</sup> / macOS <sup>6</sup>
-- Python 3.10+
+- Python 3.12+
 - [Docker](https://www.docker.com/get-started "") <sup>7</sup>
 - Available TCP Ports: <sup>8</sup>
 
@@ -159,7 +159,7 @@ User can choose between 2 types of installations:
     - _If you use a firewall, be sure to open traffic publicly on NGINX port, otherwise kobo-install cannot work_
     - _By default, additional ports are not exposed except when using multi servers configuration. If you choose to expose them, **be sure to not expose them publicly** (e.g. use a firewall and allow traffic between front-end and back-end containers only. NGINX port still has to stay publicly opened though)._
 
-<sup>5)</sup> _It has been tested with Ubuntu 20.04, 22.04 and 24.04_
+<sup>5)</sup> _It has been tested with Ubuntu 22.04 and 24.04_
 
 <sup>6)</sup> _Docker on macOS is slow. First boot usually takes a while to be ready. You may have to answer `Yes` once or twice to question `Wait for another 600 seconds?` when prompted_
 
@@ -188,17 +188,9 @@ You can also [this gist](https://gist.github.com/jnm/dd323e0ff5be0d79e12e76bb9df
 
 ### Tests
 
-Tests can be run with `tox`.  
-Be sure it is installed before running the tests.
+Tests require Python 3.12+ and can be run with `pytest`:
 
-```
-$kobo-install> sudo apt install python3-pip
-$kobo-install> pip3 install tox
-$kobo-install> tox
-```
-or
-
-```
-$kobo-install> sudo apt install tox
-$kobo-install> tox
+```shell
+$kobo-install> pip install -r requirements_tests.txt
+$kobo-install> pytest -vv
 ```

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,2 +1,2 @@
 netifaces==0.11.0
-pytest==8.4.2
+pytest==9.0.3

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,13 +1,2 @@
-atomicwrites==1.4.0
-attrs==21.4.0
-iniconfig==1.1.1
-more-itertools==8.12.0
 netifaces==0.11.0
-packaging==21.3
-pathlib2==2.3.2
-pluggy==1.0.0
-py==1.11.0
-pyparsing==3.0.8
-pytest==7.1.1
-six==1.16.0
-tomli==2.0.1
+pytest==8.4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,0 @@
-# content of: tox.ini , put in same dir as setup.py
-[tox]
-skipsdist=True
-envlist = py38,py310,py312
-
-[testenv]
-deps = -rrequirements_tests.txt
-commands =
-    pytest -vv {posargs} --disable-pytest-warnings


### PR DESCRIPTION
## Summary

Drops the tox test runner in favour of calling pytest directly, and raises the minimum Python version to 3.12.

## Notes

- `tox.ini` deleted; CI (`pytest.yml`) now targets Python 3.12 only.
- `requirements_tests.txt` stripped down to two direct deps: `pytest==8.4.2` and `netifaces==0.11.0`. Transitive deps (attrs, iniconfig, packaging, pluggy, pyparsing, six, tomli, etc.) were pinned explicitly but are no longer needed or are stdlib in 3.12.
- `netifaces` is only imported at runtime on non-Linux platforms (`helpers/network.py`); it has no Python 3.12 wheel but compiles fine from source.
- README updated: Python 3.10+ → 3.12+, Ubuntu 20.04 removed (EOL April 2025), Tests section replaced with a two-line `pip install` + `pytest` invocation.

## Preview steps

```shell
pip install -r requirements_tests.txt
pytest -vv --disable-pytest-warnings
```