### PR TITLE
fix: confirm overwrite before writing .run.conf DEV-2191

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -154,9 +154,8 @@ class Config(metaclass=Singleton):
             # writes `.run.conf`, and the setup flows then render the
             # environment files with `force=True`. Asking here, after every
             # question (including the install path) has been answered, ensures
-            # declining leaves every existing file on disk untouched. Local
-            # import avoids a circular dependency.
-            from helpers.template import Template
+            # declining leaves every existing file on disk untouched.
+            from helpers.template import Template  # avoids circular import
             if not Template.confirm_overwrite(self):
                 sys.exit(0)
 

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -103,6 +103,16 @@ class Config(metaclass=Singleton):
             self.__welcome()
             self.__dict = self.get_upgraded_dict()
 
+            # Confirm now, before asking any question or writing `.run.conf`
+            # (via `write_config()` at the end of this method), that the user
+            # really wants to overwrite an existing install. Declining here
+            # leaves every file on disk untouched. The setup flows then pass
+            # `force=True` to `Template.render()` to avoid asking twice.
+            # Local import avoids a circular dependency.
+            from helpers.template import Template
+            if not Template.confirm_overwrite(self):
+                sys.exit(0)
+
             self.__create_directory()
             self.__questions_advanced_options()
             self.__questions_installation_type()

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -103,16 +103,6 @@ class Config(metaclass=Singleton):
             self.__welcome()
             self.__dict = self.get_upgraded_dict()
 
-            # Confirm now, before asking any question or writing `.run.conf`
-            # (via `write_config()` at the end of this method), that the user
-            # really wants to overwrite an existing install. Declining here
-            # leaves every file on disk untouched. The setup flows then pass
-            # `force=True` to `Template.render()` to avoid asking twice.
-            # Local import avoids a circular dependency.
-            from helpers.template import Template
-            if not Template.confirm_overwrite(self):
-                sys.exit(0)
-
             self.__create_directory()
             self.__questions_advanced_options()
             self.__questions_installation_type()
@@ -159,6 +149,16 @@ class Config(metaclass=Singleton):
                 self.__secure_mongo()
 
             self.__questions_backup()
+
+            # Confirm before persisting anything. `write_config()` (below)
+            # writes `.run.conf`, and the setup flows then render the
+            # environment files with `force=True`. Asking here, after every
+            # question (including the install path) has been answered, ensures
+            # declining leaves every existing file on disk untouched. Local
+            # import avoids a circular dependency.
+            from helpers.template import Template
+            if not Template.confirm_overwrite(self):
+                sys.exit(0)
 
             self.write_config()
 

--- a/helpers/setup.py
+++ b/helpers/setup.py
@@ -68,7 +68,9 @@ class Setup:
         response = CLI.yes_no_question('Do you want to proceed?')
         if response is True:
             current_dict = config.build()
-            Template.render(config)
+            # `build()` already asked for overwrite confirmation before writing
+            # anything, so skip the duplicate prompt here.
+            Template.render(config, force=True)
             Setup.update_hosts(current_dict)
             question = 'Do you want to (re)start containers?'
             response = CLI.yes_no_question(question)

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -73,20 +73,12 @@ class Template:
                                       filenames)
 
     @classmethod
-    def confirm_overwrite(cls, config, force=False):
+    def confirm_overwrite(cls, config: Config, force: bool = False) -> bool:
         """
-        Warns the user when existing environment files would be overwritten
-        and asks them to confirm.
-
-        Must be called *before* anything is written to disk (including
-        `.run.conf`), so that declining leaves every existing file untouched.
-
-        Args:
-            config (helpers.config.Config)
-            force (bool): skip the check entirely when `True`
-
-        Returns:
-            bool: `True` if it is safe to proceed, `False` if declined.
+        Warn when existing environment files would be overwritten and ask the
+        user to confirm. Must be called before anything is written to disk
+        (including `.run.conf`) so that declining leaves every file untouched.
+        Returns `True` to proceed, `False` if the user declined.
         """
         if force:
             return True

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -28,24 +28,9 @@ class Template:
         template_variables = cls.__get_template_variables(config)
 
         environment_directory = config.get_env_files_path()
-        unique_id = cls.__read_unique_id(environment_directory)
 
-        if (
-            not force and unique_id
-            and str(dict_.get('unique_id', '')) != str(unique_id)
-        ):
-            message = (
-                'WARNING!\n\n'
-                'Existing environment files are detected. Files will be '
-                'overwritten.'
-            )
-            CLI.framed_print(message)
-            response = CLI.yes_no_question(
-                'Do you want to continue?',
-                default=False
-            )
-            if not response:
-                sys.exit(0)
+        if not cls.confirm_overwrite(config, force=force):
+            sys.exit(0)
 
         cls.__write_unique_id(environment_directory, dict_['unique_id'])
 
@@ -86,6 +71,42 @@ class Template:
                                       root,
                                       destination_directory,
                                       filenames)
+
+    @classmethod
+    def confirm_overwrite(cls, config, force=False):
+        """
+        Warns the user when existing environment files would be overwritten
+        and asks them to confirm.
+
+        Must be called *before* anything is written to disk (including
+        `.run.conf`), so that declining leaves every existing file untouched.
+
+        Args:
+            config (helpers.config.Config)
+            force (bool): skip the check entirely when `True`
+
+        Returns:
+            bool: `True` if it is safe to proceed, `False` if declined.
+        """
+        if force:
+            return True
+
+        dict_ = config.get_dict()
+        unique_id = cls.__read_unique_id(config.get_env_files_path())
+
+        if unique_id and str(dict_.get('unique_id', '')) != str(unique_id):
+            message = (
+                'WARNING!\n\n'
+                'Existing environment files are detected. Files will be '
+                'overwritten.'
+            )
+            CLI.framed_print(message)
+            return CLI.yes_no_question(
+                'Do you want to continue?',
+                default=False
+            )
+
+        return True
 
     @classmethod
     def render_maintenance(cls, config):

--- a/run.py
+++ b/run.py
@@ -41,7 +41,9 @@ def run(force_setup=False):
         if force_setup:
             dict_ = config.build()
             Setup.clone_kobodocker(config)
-            Template.render(config)
+            # `build()` already asked for overwrite confirmation before writing
+            # anything, so skip the duplicate prompt here.
+            Template.render(config, force=True)
             Setup.update_hosts(dict_)
         else:
             if config.auto_detect_network():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,43 @@ def test_installation():
     return config
 
 
+@patch('helpers.config.Network.get_primary_ip',
+       MagicMock(return_value='1.2.3.4'))
+def test_build_aborts_before_writing_when_overwrite_declined():
+    # Regression (dev-2191): the overwrite confirmation must run at the END of
+    # `build()`, after every question (including the install path), and must
+    # abort before `.run.conf` is written. Otherwise declining cannot protect
+    # `.run.conf`, and a path chosen mid-setup would be checked against a stale
+    # location.
+    config = read_config()
+    config._Config__dict['advanced'] = False
+    config._Config__dict['local_installation'] = True
+
+    noop = MagicMock()
+    write_config = MagicMock()
+    with patch.multiple(
+        'helpers.config.Config',
+        _Config__welcome=noop,
+        _Config__create_directory=noop,
+        _Config__questions_advanced_options=noop,
+        _Config__questions_installation_type=noop,
+        _Config__detect_network=noop,
+        _Config__questions_smtp=noop,
+        _Config__questions_super_user_credentials=noop,
+        _Config__secure_mongo=noop,
+        _Config__questions_backup=noop,
+        write_config=write_config,
+    ), patch(
+        'helpers.template.Template.confirm_overwrite',
+        MagicMock(return_value=False),
+    ) as mock_confirm:
+        with pytest.raises(SystemExit):
+            config.build()
+
+    mock_confirm.assert_called_once()
+    write_config.assert_not_called()
+
+
 @patch('helpers.config.Config._Config__clone_repo',
        MagicMock(return_value=True))
 def test_staging_mode():

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -62,6 +62,93 @@ def test_render_templates():
         shutil.rmtree(WORK_DIR)
 
 
+def _config_with_unique_id(unique_id):
+    config = read_config()
+    config._Config__dict['unique_id'] = unique_id
+    return config
+
+
+@patch(
+    'helpers.config.Config.get_env_files_path',
+    MagicMock(return_value='/tmp'),
+)
+def test_confirm_overwrite_declined_on_mismatch():
+    # Existing env files with a different unique_id -> the user is asked and
+    # says No. `confirm_overwrite` must return `False` so callers abort before
+    # writing anything.
+    config = _config_with_unique_id('111')
+    with patch(
+        'helpers.template.Template._Template__read_unique_id',
+        MagicMock(return_value='999')
+    ), patch(
+        'helpers.cli.CLI.yes_no_question', MagicMock(return_value=False)
+    ) as mock_question:
+        assert Template.confirm_overwrite(config) is False
+        mock_question.assert_called_once()
+
+
+@patch(
+    'helpers.config.Config.get_env_files_path',
+    MagicMock(return_value='/tmp'),
+)
+def test_confirm_overwrite_accepted_on_mismatch():
+    config = _config_with_unique_id('111')
+    with patch(
+        'helpers.template.Template._Template__read_unique_id',
+        MagicMock(return_value='999')
+    ), patch(
+        'helpers.cli.CLI.yes_no_question', MagicMock(return_value=True)
+    ) as mock_question:
+        assert Template.confirm_overwrite(config) is True
+        mock_question.assert_called_once()
+
+
+@patch(
+    'helpers.config.Config.get_env_files_path',
+    MagicMock(return_value='/tmp'),
+)
+def test_confirm_overwrite_force_skips_prompt():
+    # `force=True` (used by the setup flows after `build()` already asked)
+    # must never prompt.
+    config = _config_with_unique_id('111')
+    with patch(
+        'helpers.template.Template._Template__read_unique_id',
+        MagicMock(return_value='999')
+    ), patch('helpers.cli.CLI.yes_no_question') as mock_question:
+        assert Template.confirm_overwrite(config, force=True) is True
+        mock_question.assert_not_called()
+
+
+@patch(
+    'helpers.config.Config.get_env_files_path',
+    MagicMock(return_value='/tmp'),
+)
+def test_confirm_overwrite_no_existing_files():
+    # Fresh install: nothing to overwrite -> proceed silently.
+    config = _config_with_unique_id('111')
+    with patch(
+        'helpers.template.Template._Template__read_unique_id',
+        MagicMock(return_value='')
+    ), patch('helpers.cli.CLI.yes_no_question') as mock_question:
+        assert Template.confirm_overwrite(config) is True
+        mock_question.assert_not_called()
+
+
+@patch(
+    'helpers.config.Config.get_env_files_path',
+    MagicMock(return_value='/tmp'),
+)
+def test_confirm_overwrite_matching_unique_id():
+    # Re-running setup on the same install -> ids match -> no nagging prompt.
+    config = _config_with_unique_id('123456789')
+    with patch(
+        'helpers.template.Template._Template__read_unique_id',
+        MagicMock(return_value='123456789')
+    ), patch('helpers.cli.CLI.yes_no_question') as mock_question:
+        assert Template.confirm_overwrite(config) is True
+        mock_question.assert_not_called()
+
+
 def test_aws_template_tokens_credentials_mode():
     vars_ = _get_template_vars({
         'use_aws': True,


### PR DESCRIPTION
The "Existing environment files are detected" confirmation lived in Template.render(), which runs after config.build() has already written .run.conf. Declining therefore could not protect .run.conf — it was overwritten regardless of the answer.

Move the confirmation into a reusable Template.confirm_overwrite() helper and call it early in Config.build(), before any question is asked and before .run.conf is written, so declining leaves every file untouched. The two build()-then-render() setup flows pass force=True to avoid prompting a second time.

Add unit tests covering declined/accepted/forced/no-files/matching-id.